### PR TITLE
fix screenshot sound playing on cancel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/eg0rmaffin/vapor-rice-i3/issues/4
-Your prepared branch: issue-4-d9cab4e04a65
-Your prepared working directory: /tmp/gh-issue-solver-1766660966602
-Your forked repository: konard/eg0rmaffin-vapor-rice-i3
-Original repository (upstream): eg0rmaffin/vapor-rice-i3
-
-Proceed.


### PR DESCRIPTION
## Summary
Fixes #4 - Screenshot snap sound was playing even when the user canceled the screenshot (pressed ESC in flameshot).

### Root Cause
The original script assumed that after running flameshot, `ls -t "$DIR" | head -n1` would return a newly created screenshot. However, when the user canceled the screenshot, no new file was created, and the command returned the most recent *existing* file. The `while [ ! -s "$screenshot" ]` check passed immediately because the old file already existed, causing the sound to play.

### Solution
Count the number of files in the screenshots directory before and after running flameshot:
- If `count_after <= count_before`, no new file was created → exit without playing sound
- If `count_after > count_before`, a new screenshot was saved → proceed with sound

### Changes
- Added file count check before and after flameshot execution
- Script now exits early (no sound, no clipboard copy) when screenshot is canceled
- Added clarifying comments

## Test Plan
- [ ] Press PrintScreen → select area → press ESC to cancel → **no sound should play**
- [ ] Press PrintScreen → select area → take screenshot → **sound should play**
- [ ] Press Numpad1 → full screen screenshot → **sound should play**

🤖 Generated with [Claude Code](https://claude.com/claude-code)