### PR TITLE
Add popular directories to Thunar sidebar

### DIFF
--- a/experiments/test-bookmarks.sh
+++ b/experiments/test-bookmarks.sh
@@ -1,46 +1,97 @@
 #!/bin/bash
-# Test script to verify Thunar bookmarks configuration
+# Test script to verify Thunar bookmarks generation logic
 
 set -e
 
-echo "=== Thunar Bookmarks Test ==="
+echo "=== Thunar Bookmarks Generation Test ==="
 echo
 
-# Check if bookmarks file exists
-if [ -f "gtk-3.0/bookmarks" ]; then
-    echo "✅ Bookmarks file exists"
-else
-    echo "❌ Bookmarks file not found"
-    exit 1
-fi
+# Define the same directories as in install.sh
+BOOKMARK_DIRS=(
+    "Downloads"
+    "Documents"
+    "Pictures"
+    "Music"
+    "Videos"
+    "Desktop"
+)
 
-# Check file format
+# Create temporary test directory
+TEST_DIR="/tmp/thunar-bookmarks-test-$$"
+mkdir -p "$TEST_DIR"
+
+# Simulate some directories exist, some don't
+mkdir -p "$TEST_DIR/Downloads"
+mkdir -p "$TEST_DIR/Documents"
+mkdir -p "$TEST_DIR/Pictures"
+# Skip Music, Videos, Desktop to test "directory not found" logic
+
+echo "📁 Test directories created in: $TEST_DIR"
+echo "   - Downloads (exists)"
+echo "   - Documents (exists)"
+echo "   - Pictures (exists)"
+echo "   - Music (NOT created)"
+echo "   - Videos (NOT created)"
+echo "   - Desktop (NOT created)"
 echo
-echo "📄 Bookmarks content:"
-cat gtk-3.0/bookmarks
+
+# Simulate the bookmarks generation logic from install.sh
+BOOKMARKS_FILE="$TEST_DIR/.config/gtk-3.0/bookmarks"
+mkdir -p "$(dirname "$BOOKMARKS_FILE")"
+
+echo "🔧 Generating bookmarks file..."
+> "$BOOKMARKS_FILE"  # Clear/create file
+found_count=0
+skipped_count=0
+
+for dir in "${BOOKMARK_DIRS[@]}"; do
+    if [ -d "$TEST_DIR/$dir" ]; then
+        echo "file://$TEST_DIR/$dir $dir" >> "$BOOKMARKS_FILE"
+        echo "  ✅ Added bookmark: $dir"
+        found_count=$((found_count + 1))
+    else
+        echo "  ⚠️ Skipped (not found): $dir"
+        skipped_count=$((skipped_count + 1))
+    fi
+done
+
+echo
+echo "📄 Generated bookmarks content:"
+cat "$BOOKMARKS_FILE"
 
 echo
 echo "🔍 Validating format..."
 
 while IFS= read -r line; do
-    # Skip empty lines
     [ -z "$line" ] && continue
-
-    # Check if line starts with file://
     if [[ $line == file://* ]]; then
         echo "  ✅ Valid bookmark: $line"
     else
         echo "  ❌ Invalid format: $line"
+        rm -rf "$TEST_DIR"
         exit 1
     fi
-done < gtk-3.0/bookmarks
+done < "$BOOKMARKS_FILE"
 
 echo
-echo "✅ All bookmarks are properly formatted"
-echo
 echo "📋 Summary:"
-echo "   - Total bookmarks: $(grep -c '^file://' gtk-3.0/bookmarks)"
+echo "   - Directories found: $found_count"
+echo "   - Directories skipped: $skipped_count"
+echo "   - Bookmarks generated: $(grep -c '^file://' "$BOOKMARKS_FILE")"
 echo "   - Format: GTK bookmarks (compatible with Thunar)"
-echo "   - Location: ~/.config/gtk-3.0/bookmarks"
+echo
+
+# Verify expected behavior
+if [ "$found_count" -eq 3 ] && [ "$skipped_count" -eq 3 ]; then
+    echo "✅ Generation logic works correctly (only existing dirs added)"
+else
+    echo "❌ Unexpected counts: found=$found_count, skipped=$skipped_count"
+    rm -rf "$TEST_DIR"
+    exit 1
+fi
+
+# Cleanup
+rm -rf "$TEST_DIR"
+
 echo
 echo "🎉 Test passed!"

--- a/experiments/test-install-section.sh
+++ b/experiments/test-install-section.sh
@@ -1,53 +1,111 @@
 #!/bin/bash
-# Test the GTK 3.0 section of install.sh
+# Test the GTK 3.0 bookmarks section of install.sh
 
 set -e
 
-echo "=== Testing GTK 3.0 Installation Section ==="
+echo "=== Testing GTK 3.0 Bookmarks Installation Section ==="
 echo
 
-# Create temporary test directory
-TEST_DIR="/tmp/thunar-test-$$"
-mkdir -p "$TEST_DIR"
-cd "$TEST_DIR"
+# Create temporary test directory structure
+TEST_DIR="/tmp/thunar-install-test-$$"
+HOME_DIR="$TEST_DIR/home/testuser"
+mkdir -p "$HOME_DIR"
+
+# Simulate user directories (these would normally be created by xdg-user-dirs)
+mkdir -p "$HOME_DIR/Downloads"
+mkdir -p "$HOME_DIR/Documents"
+mkdir -p "$HOME_DIR/Pictures"
+mkdir -p "$HOME_DIR/Music"
+mkdir -p "$HOME_DIR/Videos"
+mkdir -p "$HOME_DIR/Desktop"
+
+echo "📁 Simulated home directory: $HOME_DIR"
+ls -la "$HOME_DIR"
+echo
 
 # Simulate dotfiles structure
-mkdir -p dotfiles/gtk-3.0
-echo "[Settings]" > dotfiles/gtk-3.0/settings.ini
-cat > dotfiles/gtk-3.0/bookmarks << 'BOOKMARKS'
-file:///home/admin/Downloads Downloads
-file:///home/admin/Documents Documents
-file:///home/admin/Pictures Pictures
-BOOKMARKS
+mkdir -p "$HOME_DIR/dotfiles/gtk-3.0"
+echo "[Settings]" > "$HOME_DIR/dotfiles/gtk-3.0/settings.ini"
 
-# Simulate the install.sh section
-mkdir -p .config/gtk-3.0
-ln -sf "$TEST_DIR/dotfiles/gtk-3.0/settings.ini" .config/gtk-3.0/settings.ini
-ln -sf "$TEST_DIR/dotfiles/gtk-3.0/bookmarks" .config/gtk-3.0/bookmarks
+# Simulate the install.sh bookmark generation section
+cd "$HOME_DIR"
 
-echo "✅ Symlinks created"
+echo "🔧 Testing bookmark generation logic..."
 echo
 
-# Verify symlinks
-if [ -L ".config/gtk-3.0/settings.ini" ]; then
+# Colors (same as install.sh)
+GREEN="\033[0;32m"
+YELLOW="\033[1;33m"
+CYAN="\033[0;36m"
+RESET="\033[0m"
+
+# Standard XDG user directories
+BOOKMARK_DIRS=(
+    "Downloads"
+    "Documents"
+    "Pictures"
+    "Music"
+    "Videos"
+    "Desktop"
+)
+
+# Create config directory and bookmarks file
+mkdir -p "$HOME_DIR/.config/gtk-3.0"
+ln -sf "$HOME_DIR/dotfiles/gtk-3.0/settings.ini" "$HOME_DIR/.config/gtk-3.0/settings.ini"
+
+# Create bookmarks file with only existing directories
+> "$HOME_DIR/.config/gtk-3.0/bookmarks"  # Clear/create file
+for dir in "${BOOKMARK_DIRS[@]}"; do
+    if [ -d "$HOME_DIR/$dir" ]; then
+        echo "file://$HOME_DIR/$dir $dir" >> "$HOME_DIR/.config/gtk-3.0/bookmarks"
+        echo -e "  ${GREEN}✅ Added bookmark: $dir${RESET}"
+    else
+        echo -e "  ${YELLOW}⚠️ Skipped (not found): $dir${RESET}"
+    fi
+done
+
+echo
+echo "📄 Generated bookmarks content:"
+cat "$HOME_DIR/.config/gtk-3.0/bookmarks"
+
+# Verify results
+echo
+echo "🔍 Verifying..."
+
+if [ -L "$HOME_DIR/.config/gtk-3.0/settings.ini" ]; then
     echo "✅ settings.ini symlink exists"
-    ls -la .config/gtk-3.0/settings.ini
 else
     echo "❌ settings.ini symlink missing"
+    rm -rf "$TEST_DIR"
     exit 1
 fi
 
-if [ -L ".config/gtk-3.0/bookmarks" ]; then
-    echo "✅ bookmarks symlink exists"
-    ls -la .config/gtk-3.0/bookmarks
+if [ -f "$HOME_DIR/.config/gtk-3.0/bookmarks" ]; then
+    echo "✅ bookmarks file exists"
+    bookmark_count=$(grep -c '^file://' "$HOME_DIR/.config/gtk-3.0/bookmarks")
+    echo "   - Contains $bookmark_count bookmarks"
+
+    if [ "$bookmark_count" -eq 6 ]; then
+        echo "✅ All 6 directories added as bookmarks"
+    else
+        echo "❌ Expected 6 bookmarks, got $bookmark_count"
+        rm -rf "$TEST_DIR"
+        exit 1
+    fi
 else
-    echo "❌ bookmarks symlink missing"
+    echo "❌ bookmarks file missing"
+    rm -rf "$TEST_DIR"
     exit 1
 fi
 
-echo
-echo "📄 Bookmarks content via symlink:"
-cat .config/gtk-3.0/bookmarks
+# Verify no hardcoded paths
+if grep -q '/home/admin' "$HOME_DIR/.config/gtk-3.0/bookmarks"; then
+    echo "❌ ERROR: Found hardcoded '/home/admin' path!"
+    rm -rf "$TEST_DIR"
+    exit 1
+else
+    echo "✅ No hardcoded paths found (uses dynamic \$HOME)"
+fi
 
 # Cleanup
 cd /

--- a/experiments/thunar-research.md
+++ b/experiments/thunar-research.md
@@ -9,9 +9,32 @@ The bookmarks file follows the GTK bookmarks format:
 file:///path/to/directory Display Name
 ```
 
+## Implementation Approach
+
+### Problem with Static File
+A static bookmarks file with hardcoded paths like `/home/admin/` doesn't work for other users.
+
+### Solution: Dynamic Generation
+Generate the bookmarks file during installation using `$HOME` variable:
+- Loop through standard XDG directories
+- Check if each directory exists before adding
+- Write bookmarks with correct user path
+
+### Code Example
+```bash
+BOOKMARK_DIRS=("Downloads" "Documents" "Pictures" "Music" "Videos" "Desktop")
+
+> ~/.config/gtk-3.0/bookmarks
+for dir in "${BOOKMARK_DIRS[@]}"; do
+    if [ -d "$HOME/$dir" ]; then
+        echo "file://$HOME/$dir $dir" >> ~/.config/gtk-3.0/bookmarks
+    fi
+done
+```
+
 ## Common Popular Directories
 - Downloads
-- Documents  
+- Documents
 - Pictures
 - Music
 - Videos
@@ -21,3 +44,4 @@ file:///path/to/directory Display Name
 - Thunar uses GTK+ file chooser bookmarks
 - File format: one bookmark per line
 - Format: URI followed by optional display name
+- XDG user directories: https://wiki.archlinux.org/title/XDG_user_directories

--- a/gtk-3.0/bookmarks
+++ b/gtk-3.0/bookmarks
@@ -1,6 +1,0 @@
-file:///home/admin/Downloads Downloads
-file:///home/admin/Documents Documents
-file:///home/admin/Pictures Pictures
-file:///home/admin/Music Music
-file:///home/admin/Videos Videos
-file:///home/admin/Desktop Desktop

--- a/install.sh
+++ b/install.sh
@@ -260,7 +260,29 @@ echo -e "${GREEN}✅ picom config linked${RESET}"
 echo -e "${CYAN}🔧 Linking GTK 3.0 settings...${RESET}"
 mkdir -p ~/.config/gtk-3.0
 ln -sf ~/dotfiles/gtk-3.0/settings.ini ~/.config/gtk-3.0/settings.ini
-ln -sf ~/dotfiles/gtk-3.0/bookmarks ~/.config/gtk-3.0/bookmarks
+
+# 🧩 Generate Thunar bookmarks for popular directories
+echo -e "${CYAN}🔧 Generating Thunar bookmarks...${RESET}"
+# Standard XDG user directories
+BOOKMARK_DIRS=(
+    "Downloads"
+    "Documents"
+    "Pictures"
+    "Music"
+    "Videos"
+    "Desktop"
+)
+
+# Create bookmarks file with only existing directories
+> ~/.config/gtk-3.0/bookmarks  # Clear/create file
+for dir in "${BOOKMARK_DIRS[@]}"; do
+    if [ -d "$HOME/$dir" ]; then
+        echo "file://$HOME/$dir $dir" >> ~/.config/gtk-3.0/bookmarks
+        echo -e "  ${GREEN}✅ Added bookmark: $dir${RESET}"
+    else
+        echo -e "  ${YELLOW}⚠️ Skipped (not found): $dir${RESET}"
+    fi
+done
 echo -e "${GREEN}✅ GTK 3.0 settings linked${RESET}"
 
 # 🧩 Alacritty


### PR DESCRIPTION
## 📋 Issue Reference
Fixes #5

## 🎯 Summary
This PR adds popular directories (Downloads, Documents, Pictures, Music, Videos, Desktop) to the Thunar file manager sidebar, addressing the issue where the sidebar only showed basic locations like Computer, admin, Recent, Trash, and mounted devices.

## 🔧 Changes Made

### 1. Dynamic Bookmark Generation (install.sh:259-283)
- **Removed static `gtk-3.0/bookmarks` file** with hardcoded paths
- **Generate bookmarks dynamically** during installation using `$HOME` variable
- **Only adds directories that exist** on the user's system
- Declarative approach: directory names are defined in a simple array

### 2. Updated Test Coverage
- Test scripts now verify the dynamic generation logic
- Tests confirm no hardcoded `/home/admin` paths are used
- Validates that only existing directories get bookmarks

## 📸 What This Solves

**Before**: Thunar sidebar only showed:
- Computer
- admin (home)
- Recent
- Trash
- Mounted devices/network

**After**: Thunar sidebar will now also include:
- Downloads
- Documents
- Pictures
- Music
- Videos
- Desktop

These directories will appear in the "Places" section of the Thunar sidebar, making it much easier to access commonly used folders.

## ✅ Technical Details

The bookmarks are generated with this declarative approach:
```bash
BOOKMARK_DIRS=(
    "Downloads"
    "Documents"
    "Pictures"
    "Music"
    "Videos"
    "Desktop"
)

for dir in "${BOOKMARK_DIRS[@]}"; do
    if [ -d "$HOME/$dir" ]; then
        echo "file://$HOME/$dir $dir" >> ~/.config/gtk-3.0/bookmarks
    fi
done
```

**Key improvements:**
- Uses `$HOME` variable instead of hardcoded `/home/admin`
- Checks if each directory exists before adding it as a bookmark
- Works for any username
- Easy to add/remove directories from the list

## 🚀 Installation
Users running `install.sh` will automatically get the bookmarks configuration. Existing users can re-run the GTK 3.0 section or manually run the generation loop.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)