### PR TITLE
Make volume OSD panel bigger and more visible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/eg0rmaffin/vapor-rice-i3/issues/27
-Your prepared branch: issue-27-45beb63c8f60
-Your prepared working directory: /tmp/gh-issue-solver-1767838745804
-Your forked repository: konard/eg0rmaffin-vapor-rice-i3
-Original repository (upstream): eg0rmaffin/vapor-rice-i3
-
-Proceed.


### PR DESCRIPTION
## Summary
- Increased the dunst volume OSD panel size for better visibility while maintaining the vaporwave aesthetic
- Made font larger and bolder (Noto Sans Bold 14)
- Expanded progress bar dimensions (14px height, 280px width)
- Added more padding and a thicker pink frame for emphasis
- Kept the original vaporwave color palette (#ff79c6 pink, #1a1a2e dark background)

## Changes
| Property | Before | After |
|----------|--------|-------|
| Font | Default (Noto Sans 10) | Noto Sans Bold 14 |
| Padding | 10px | 16px vertical, 20px horizontal |
| Progress bar height | 8px | 14px |
| Progress bar width | 180px | 280px |
| Frame width | 2px | 3px |
| Frame color | #8be9fd (cyan) | #ff79c6 (pink) |

## Test plan
- [ ] Restart dunst after applying the config: `killall dunst && dunst &`
- [ ] Test volume adjustment with keyboard shortcuts or `pamixer --increase 5`
- [ ] Verify the OSD appears larger and more visible
- [ ] Confirm the vaporwave aesthetic is preserved

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)