### PR TITLE
Issue #30 - Snapshot setup already integrated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/eg0rmaffin/vapor-rice-i3/issues/30
+Your prepared branch: issue-30-a6642d585729
+Your prepared working directory: /tmp/gh-issue-solver-1768231859506
+Your forked repository: konard/eg0rmaffin-vapor-rice-i3
+Original repository (upstream): eg0rmaffin/vapor-rice-i3
+
+Proceed.


### PR DESCRIPTION
## Summary

After investigation, this issue appears to already be resolved.

### Findings

The snapshot setup was fully integrated into `install.sh` in PR #21 (merged 2026-01-12):

1. **Snapshot helper scripts** (lines 416-424 of `install.sh`):
   ```bash
   echo -e "${CYAN}🔧 Linking snapshot scripts...${RESET}"
   mkdir -p ~/.local/bin
   for script in snapshot-create snapshot-list snapshot-diff snapshot-delete snapshot-rollback; do
       if [ -f ~/dotfiles/bin/snapshots/$script ]; then
           ln -sf ~/dotfiles/bin/snapshots/$script ~/.local/bin/$script
           echo -e "${GREEN}✅ $script linked${RESET}"
       fi
   done
   ```

2. **Automatic snapshot configuration** (lines 427-428):
   ```bash
   source ~/dotfiles/scripts/snapshot_setup.sh
   setup_snapshots
   ```

### Verification Results

- ✅ `install.sh` syntax valid
- ✅ `snapshot_setup.sh` syntax valid  
- ✅ All 5 snapshot helper scripts present and valid

### Recommendation

This PR can be closed since the functionality requested in issue #30 is already present in the repository. If there are additional requirements, please clarify and a new PR can be opened.

---
*Analysis performed by AI issue solver*


Fixes eg0rmaffin/vapor-rice-i3#30