### PR TITLE
Fix rofi theme parsing error in border-color syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/eg0rmaffin/vapor-rice-i3/issues/34
-Your prepared branch: issue-34-8a90ef10784a
-Your prepared working directory: /tmp/gh-issue-solver-1768344617784
-Your forked repository: konard/eg0rmaffin-vapor-rice-i3
-Original repository (upstream): eg0rmaffin/vapor-rice-i3
-
-Proceed.


### PR DESCRIPTION
## Summary

Fixes the rofi theme parsing error in the poweroff menu by correcting invalid `border-color` syntax.

### Issue Reference
Fixes #34

### Root Cause

The `border-color` property in rofi themes only accepts a **single color value**, not CSS-like shorthand with four values for different sides. The previous code used invalid syntax like:

```css
border-color: @win95-light @win95-dark @win95-dark @win95-light;
```

This caused the parsing error:
> **Error while parsing theme:** syntax error, unexpected Reference, expecting "property close (';')"
> Location: line 100 column 35 to line 100 column 47

### Solution

Changed all `border-color` declarations to use single color values:
- **Normal state buttons**: `@win95-light` (lighter border)
- **Selected/pressed state buttons**: `@win95-dark` (darker border for visual feedback)

This maintains the Win95-inspired visual distinction between normal and pressed button states while being valid rofi theme syntax.

### Files Changed

| File | Description |
|------|-------------|
| `rofi/power-menu.rasi` | Fixed 6 invalid border-color declarations |

### Testing

```bash
# Theme now validates without errors
rofi -rasi-validate rofi/power-menu.rasi
# (no output = success)
```

---
*Generated with [Claude Code](https://claude.com/claude-code)*