### PR TITLE
Fix dunst config: move global-only settings to [global] section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/eg0rmaffin/vapor-rice-i3/issues/43
-Your prepared branch: issue-43-0ebbaf3c5d37
-Your prepared working directory: /tmp/gh-issue-solver-1769565829912
-Your forked repository: konard/eg0rmaffin-vapor-rice-i3
-Original repository (upstream): eg0rmaffin/vapor-rice-i3
-
-Proceed.


### PR DESCRIPTION
## Summary

- **Root Cause**: The dunst configuration from PR #29 tried to override settings like `font`, `padding`, and `progress_bar_*` in the `[volume-osd]` rule section, but these settings are **global-only** in dunst and cannot be overridden per-rule. Per the [dunst(5) manpage](https://man.archlinux.org/man/dunst.5.en), only color-related settings (`background`, `foreground`, `frame_color`, `highlight`) can be overridden in rules.
- **Fix**: Moved all global-only settings to the `[global]` section where they actually take effect. The rule sections now only contain color overrides which work correctly.

## Settings Changed (in [global] section)

| Setting | Before | After |
|---------|--------|-------|
| font | Noto Sans 10 | Noto Sans Bold 14 |
| padding | 10 | 16 |
| horizontal_padding | (none) | 20 |
| frame_width | 2 | 3 |
| progress_bar_height | 8 | 14 |
| progress_bar_frame_width | 1 | 2 |
| progress_bar_min_width | 180 | 280 |
| progress_bar_max_width | 180 | 280 |

## Test Plan

- [ ] Restart dunst: `killall dunst && dunst &`
- [ ] Test volume OSD: Press volume keys and verify the notification is bigger with larger font
- [ ] Verify progress bar is wider (280px) and taller (14px)
- [ ] Check that the pink vaporwave colors still apply to volume notifications

## Issue Reference

Fixes eg0rmaffin/vapor-rice-i3#43

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)