### PR TITLE
Make dunst notifications wider and position below i3bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/eg0rmaffin/vapor-rice-i3/issues/51
-Your prepared branch: issue-51-c886eb983d38
-Your prepared working directory: /tmp/gh-issue-solver-1769575179296
-Your forked repository: konard/eg0rmaffin-vapor-rice-i3
-Original repository (upstream): eg0rmaffin/vapor-rice-i3
-
-Proceed.


### PR DESCRIPTION
## Summary
- Add explicit width setting `(0, 400)` for wider notifications (dynamic width up to 400px)
- Increase progress bar width from 280px to 360px for better proportions with wider window
- Increase Y-offset from 20px to 50px to prevent overlap with i3bar at top

## Technical Details
The i3bar configuration uses `font pango:FiraCode Nerd Font 14` which results in approximately 24px bar height. Combined with the outer gaps of 10px, the total clearance needed is around 34px. Using 50px offset provides comfortable visual separation between the i3bar and dunst notifications.

Fixes #51

## Test Plan
- [ ] Test with `notify-send "Test" "This is a test notification"` to verify wider appearance
- [ ] Verify notifications spawn below i3bar (not overlapping)
- [ ] Test volume/brightness OSD to verify progress bar looks proportional
- [ ] Restart dunst with `killall dunst && dunst &` to apply changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)