### PR TITLE
Declarative visual semantics for XDG user directories (Thunar / icon theme integration)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -302,9 +302,10 @@ done
 # This file is read by Thunar and other file managers to identify
 # which directories should display semantic icons (folder-download, folder-documents, etc.)
 # Desktop is intentionally excluded as it's not part of the i3 workflow.
-echo -e "${CYAN}🎨 Generating XDG user-dirs.dirs for semantic folder icons...${RESET}"
+echo -e "${CYAN}🎨 Checking XDG user-dirs.dirs for semantic folder icons...${RESET}"
 mkdir -p ~/.config
-cat > ~/.config/user-dirs.dirs << 'EOF'
+
+_xdg_dirs_expected=$(cat << 'EOF'
 # This file is written by install.sh as part of the declarative setup.
 # XDG user directories are explicitly declared here for visual semantics.
 # See also: https://wiki.archlinux.org/title/XDG_user_directories
@@ -317,17 +318,32 @@ XDG_PICTURES_DIR="$HOME/Pictures"
 XDG_MUSIC_DIR="$HOME/Music"
 XDG_VIDEOS_DIR="$HOME/Videos"
 EOF
-echo -e "${GREEN}✅ XDG user-dirs.dirs generated (enables semantic folder icons)${RESET}"
+)
+
+if [ -f ~/.config/user-dirs.dirs ] && [ "$(cat ~/.config/user-dirs.dirs)" = "$_xdg_dirs_expected" ]; then
+    echo -e "${GREEN}✅ XDG user-dirs.dirs already correct${RESET}"
+else
+    echo "$_xdg_dirs_expected" > ~/.config/user-dirs.dirs
+    echo -e "${GREEN}✅ XDG user-dirs.dirs generated (enables semantic folder icons)${RESET}"
+fi
 
 # 🧩 Generate Thunar bookmarks for declared XDG directories
 # Bookmarks are derived only from the declared directories above.
-echo -e "${CYAN}🔧 Generating Thunar bookmarks...${RESET}"
-> ~/.config/gtk-3.0/bookmarks  # Clear/create file
+echo -e "${CYAN}🔧 Checking Thunar bookmarks...${RESET}"
+
+_bookmarks_expected=""
 for dir in "${XDG_USER_DIRS[@]}"; do
-    echo "file://$HOME/$dir $dir" >> ~/.config/gtk-3.0/bookmarks
-    echo -e "  ${GREEN}✅ Added bookmark: $dir${RESET}"
+    _bookmarks_expected+="file://$HOME/$dir $dir"$'\n'
 done
-echo -e "${GREEN}✅ GTK 3.0 settings linked${RESET}"
+# Remove trailing newline for comparison
+_bookmarks_expected="${_bookmarks_expected%$'\n'}"
+
+if [ -f ~/.config/gtk-3.0/bookmarks ] && [ "$(cat ~/.config/gtk-3.0/bookmarks)" = "$_bookmarks_expected" ]; then
+    echo -e "${GREEN}✅ Thunar bookmarks already correct${RESET}"
+else
+    echo "$_bookmarks_expected" > ~/.config/gtk-3.0/bookmarks
+    echo -e "${GREEN}✅ Thunar bookmarks generated${RESET}"
+fi
 
 # 🧩 Alacritty
 echo -e "${CYAN}🔧 Linking Alacritty config...${RESET}"


### PR DESCRIPTION
## Summary

Implements declarative visual semantics for XDG user directories as described in issue #69.

### Problem

The Chicago95 icon theme is correctly installed and provides semantic folder icons (`folder-download`, `folder-documents`, `folder-pictures`, `folder-music`, `folder-videos`), but XDG user directories were displayed with generic folder icons because Thunar had no way to know which directories were "special".

### Solution

Generate `~/.config/user-dirs.dirs` - the standard freedesktop.org configuration file that tells file managers which directories are XDG special directories.

When this file exists with proper declarations:
- Thunar recognizes Downloads, Documents, Pictures, Music, Videos as special XDG directories
- The icon theme's semantic folder icons are automatically applied
- Visual layer becomes a projection of the declarative model (as intended)

### Idempotency

Both `user-dirs.dirs` and GTK bookmarks generation are fully idempotent:
- Expected file content is computed first, then compared against the existing file
- If the file already contains the correct content, it is **not rewritten** (no unnecessary disk writes)
- If the file is missing or different, it is created/updated
- This follows the same check-before-act pattern used throughout `install.sh`

### Changes

| File | Change |
|------|--------|
| `install.sh` | Idempotent generation of `~/.config/user-dirs.dirs` and GTK bookmarks |
| `experiments/test-xdg-icons.sh` | Test script verifying content correctness and idempotency |

### Declared XDG Directories

| Directory | XDG Variable | Icon Name |
|-----------|--------------|-----------|
| Downloads | `XDG_DOWNLOAD_DIR` | `folder-download` |
| Documents | `XDG_DOCUMENTS_DIR` | `folder-documents` |
| Pictures | `XDG_PICTURES_DIR` | `folder-pictures` |
| Music | `XDG_MUSIC_DIR` | `folder-music` |
| Videos | `XDG_VIDEOS_DIR` | `folder-videos` |
| Desktop | Not declared | Not part of i3 workflow |

### How It Works

1. `install.sh` creates XDG directories (already implemented in PR #66)
2. `install.sh` generates `~/.config/user-dirs.dirs` declaring which directories are XDG special (idempotent)
3. `install.sh` generates GTK bookmarks from the same declared directories (idempotent)
4. Thunar reads `user-dirs.dirs` and maps directories to semantic icon names
5. Chicago95 icon theme provides the actual icons (`folder-download.png`, etc.)

### Test Plan

- [x] Test script verifies user-dirs.dirs is generated with correct content
- [x] Test script verifies all 5 XDG directories are declared
- [x] Test script verifies Desktop is NOT declared (excluded)
- [x] Test script verifies file format is valid shell syntax
- [x] Test script verifies paths use `$HOME` variable (portable)
- [x] Test script verifies idempotency (file not rewritten when already correct)

Fixes #69