### PR TITLE
Fix keyboard backlight binding: use Fn-keys instead of Mod+Space

### DIFF
--- a/bin/kbd-backlight.sh
+++ b/bin/kbd-backlight.sh
@@ -164,6 +164,13 @@ case "$1" in
         echo "Available brightness levels: ${LEVELS[*]}"
         echo "Max brightness: $MAX_BRIGHTNESS"
         ;;
+    notify)
+        # Show OSD notification only (without changing brightness)
+        # Used when kernel/firmware already handled the brightness change (e.g. Fn+Space)
+        # Small delay to let kernel finish writing brightness value before reading it for OSD
+        sleep 0.05
+        show_osd
+        ;;
     status)
         DEVICE_NAME=$(basename "$KBD_BACKLIGHT")
         LEVELS=($(get_brightness_levels))
@@ -172,13 +179,14 @@ case "$1" in
         echo "Available levels: ${LEVELS[*]}"
         ;;
     *)
-        echo "Usage: $0 {cycle|up|down|toggle|max|off|get|levels|status}"
+        echo "Usage: $0 {cycle|up|down|toggle|notify|max|off|get|levels|status}"
         echo ""
         echo "Commands:"
         echo "  cycle   - Cycle through brightness levels (off -> low -> high -> off)"
         echo "  up      - Increase keyboard backlight brightness"
         echo "  down    - Decrease keyboard backlight brightness"
         echo "  toggle  - Toggle keyboard backlight on/off"
+        echo "  notify  - Show OSD notification only (for Fn-key handled by kernel)"
         echo "  max     - Set keyboard backlight to maximum"
         echo "  off     - Turn off keyboard backlight"
         echo "  get     - Get current brightness value"

--- a/i3/includes/kbd-backlight.conf
+++ b/i3/includes/kbd-backlight.conf
@@ -3,6 +3,8 @@
 # Brightness levels are auto-detected based on hardware capabilities
 
 # Standard XF86 keyboard backlight keys (Fn+Space / Fn+F5 etc. depending on laptop)
+# Note: Fn+Space (XF86KbdLightOnOff) toggles backlight at kernel/firmware level;
+# i3 binding only shows the OSD notification via dunst after the kernel handles it
 bindsym XF86KbdBrightnessUp exec --no-startup-id ~/dotfiles/bin/kbd-backlight.sh up
 bindsym XF86KbdBrightnessDown exec --no-startup-id ~/dotfiles/bin/kbd-backlight.sh down
-bindsym XF86KbdLightOnOff exec --no-startup-id ~/dotfiles/bin/kbd-backlight.sh cycle
+bindsym XF86KbdLightOnOff exec --no-startup-id ~/dotfiles/bin/kbd-backlight.sh notify


### PR DESCRIPTION
## Summary

- Remove incorrect `$mod+space` binding for keyboard backlight — Fn+Space is the standard laptop key and already works at hardware level
- Add `notify` command to `kbd-backlight.sh` that shows dunst OSD notification without changing brightness
- Bind `XF86KbdLightOnOff` to `notify` so dunst fires when Fn+Space is pressed (kernel handles the actual backlight toggle)
- Keep `XF86KbdBrightnessUp` / `XF86KbdBrightnessDown` with full control (up/down commands)

## Details

The `$mod+space` binding was incorrectly used for keyboard backlight cycling. On laptops, `Fn+Space` maps to `XF86KbdLightOnOff` at the hardware/kernel level — the kernel/firmware handles the actual backlight toggle directly.

**Problem:** On master, only `$mod+space` triggered the dunst OSD notification. `Fn+Space` toggled the backlight (via kernel) but showed no notification. The old `XF86KbdLightOnOff` binding tried to `toggle` the brightness in software, which conflicted with the kernel's own toggle.

**Solution:** A new `notify` command in `kbd-backlight.sh` that only reads the current brightness (after kernel changed it) and shows the OSD via dunst — no brightness write, no conflict. A 50ms delay ensures the kernel finishes writing the new brightness value before the OSD reads it.

Fixes eg0rmaffin/vapor-rice-i3#71

🤖 Generated with [Claude Code](https://claude.com/claude-code)