### PR TITLE
Fix D-Bus environment for kbd-backlight-watcher OSD notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/eg0rmaffin/vapor-rice-i3/issues/71
-Your prepared branch: issue-71-45924f758688
-Your prepared working directory: /tmp/gh-issue-solver-1770104953293
-Your forked repository: konard/eg0rmaffin-vapor-rice-i3
-Original repository (upstream): eg0rmaffin/vapor-rice-i3
-
-Proceed.


### PR DESCRIPTION
## Summary

Fix dunst OSD notifications not appearing when using Fn+Space for keyboard backlight toggle.

## Problem

After PR #77 added the `kbd-backlight-watcher.sh` daemon, dunst OSD notifications still don't appear when pressing Fn+Space. Volume Fn-keys work fine, but keyboard backlight OSD is broken.

**Root cause**: The watcher daemon runs as a background process started from i3 config (`exec_always`). When the background subshell calls `notify-send`, it loses access to the `DBUS_SESSION_BUS_ADDRESS` and `DISPLAY` environment variables needed to communicate with dunst via D-Bus.

Volume Fn-keys work because they run directly in i3's process context (via `bindsym ... exec`), which inherits the proper D-Bus environment.

## Solution

1. **Capture environment at startup**: Store `DISPLAY` and `DBUS_SESSION_BUS_ADDRESS` in variables when the watcher script starts
2. **D-Bus discovery fallback**: If `DBUS_SESSION_BUS_ADDRESS` is not in the environment, try to discover it:
   - Check dbus-daemon process environment via `/proc/{pid}/environ`
   - Check XDG runtime directory for standard bus socket
3. **Export to subshell**: Pass captured environment variables when calling the OSD script
4. **Debug output**: Add D-Bus info to `start` and `status` commands for troubleshooting

## Test Plan

- [ ] After running `install.sh`, verify `inotify-tools` is installed
- [ ] Press `Fn+Space` (keyboard backlight toggle) and verify dunst OSD appears
- [ ] Run `~/dotfiles/bin/kbd-backlight-watcher.sh status` to verify D-Bus environment is detected
- [ ] Reload i3 config (`$mod+Shift+r`) and verify OSD still works after restart
- [ ] Compare with volume Fn-keys - both should show dunst OSD

## Technical Details

```bash
# The watcher now shows D-Bus info when started:
Starting keyboard backlight watcher...
Watching: /sys/class/leds/asus::kbd_backlight/brightness
D-Bus: unix:path=/run/user/1000/bus
Display: :0

# Status command includes D-Bus debugging:
~/dotfiles/bin/kbd-backlight-watcher.sh status
```

Fixes eg0rmaffin/vapor-rice-i3#71

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)