### PR TITLE
Import D-Bus environment to systemd user session for Fn+Space OSD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/eg0rmaffin/vapor-rice-i3/issues/71
-Your prepared branch: issue-71-28d18973879c
-Your prepared working directory: /tmp/gh-issue-solver-1770109823486
-Your forked repository: konard/eg0rmaffin-vapor-rice-i3
-Original repository (upstream): eg0rmaffin/vapor-rice-i3
-
-Proceed.


### PR DESCRIPTION
## Summary

Fix dunst OSD notifications not appearing when pressing Fn+Space for keyboard backlight toggle.

## Root Cause Analysis

**Why the systemd service approach from PR #79 wasn't enough:**

Even with the systemd user service properly running and watching sysfs for brightness changes, the OSD notification wasn't appearing because:

1. When using `startx`/`xinit` with `dbus-launch`, the D-Bus session bus is created at a random path like `/tmp/dbus-XXXXXXXX`
2. **Systemd user services don't automatically know about this session bus** unless explicitly told via `import-environment`
3. The watcher service could detect brightness changes, but `notify-send` failed silently because it couldn't connect to the D-Bus session bus where dunst is listening

**How to verify this was the issue:**

The user reported this status output:
```
D-Bus environment:
  DISPLAY: :0
  DBUS_SESSION_BUS_ADDRESS: unix:path=/tmp/dbus-guXEKt8B04,guid=...
```

Note the `/tmp/dbus-*` path - this is dbus-launch style, not the standard systemd bus at `/run/user/$UID/bus`.

## Solution

Add `systemctl --user import-environment` in `.xinitrc` right after `dbus-launch` to export `DBUS_SESSION_BUS_ADDRESS` and `DISPLAY` to the systemd user session:

```bash
eval "$(dbus-launch --sh-syntax --exit-with-session)"

# Import D-Bus and display environment into systemd user session
# This is required for systemd user services to access the session bus
systemctl --user import-environment DISPLAY DBUS_SESSION_BUS_ADDRESS XDG_CURRENT_DESKTOP
```

This makes the session bus address available to all systemd user services, including `kbd-backlight-watcher.service`.

## Test Plan

After applying this fix:

1. Log out completely and log back in (or reboot)
2. Check service status:
   ```bash
   systemctl --user status kbd-backlight-watcher.service
   ```
3. Verify D-Bus is now accessible from systemd:
   ```bash
   systemctl --user show-environment | grep DBUS
   ```
4. Press `Fn+Space` and verify dunst OSD notification appears

## Manual fix for existing installations

If you already have the dotfiles installed:

```bash
cd ~/dotfiles && git pull
```

Then log out and log back in (the xinitrc change takes effect on next login).

Fixes #71

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)