### PR TITLE
Activate graphical-session.target in .xinitrc for Fn+Space keyboard backlight OSD

### DIFF
--- a/.xinitrc
+++ b/.xinitrc
@@ -22,6 +22,11 @@ eval "$(dbus-launch --sh-syntax --exit-with-session)"
 # (e.g., kbd-backlight-watcher.service needs DBUS_SESSION_BUS_ADDRESS for dunst notifications)
 systemctl --user import-environment DISPLAY DBUS_SESSION_BUS_ADDRESS XDG_CURRENT_DESKTOP
 
+# Activate graphical-session.target for systemd user services
+# startx/.xinitrc does not activate this target automatically (unlike display managers)
+# This pulls in services like kbd-backlight-watcher.service that are WantedBy=graphical-session.target
+systemctl --user start graphical-session.target
+
 # 🎹 Клавиатура
 setxkbmap -layout us,ru -option grp:alt_shift_toggle
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/eg0rmaffin/vapor-rice-i3/issues/71
-Your prepared branch: issue-71-d74e0084a93a
-Your prepared working directory: /tmp/gh-issue-solver-1770373867408
-Your forked repository: konard/eg0rmaffin-vapor-rice-i3
-Original repository (upstream): eg0rmaffin/vapor-rice-i3
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/eg0rmaffin/vapor-rice-i3/issues/71
+Your prepared branch: issue-71-d74e0084a93a
+Your prepared working directory: /tmp/gh-issue-solver-1770373867408
+Your forked repository: konard/eg0rmaffin-vapor-rice-i3
+Original repository (upstream): eg0rmaffin/vapor-rice-i3
+
+Proceed.

--- a/experiments/test-graphical-session-target.sh
+++ b/experiments/test-graphical-session-target.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Test script to verify the graphical-session.target fix
+# Run this on the actual machine to verify the watcher starts properly
+
+echo "=== Graphical Session Target Diagnostic ==="
+echo ""
+
+# Check if graphical-session.target is active
+echo "1. Checking graphical-session.target status:"
+systemctl --user is-active graphical-session.target 2>/dev/null
+echo "   Full status:"
+systemctl --user status graphical-session.target 2>/dev/null | head -5
+echo ""
+
+# Check if kbd-backlight-watcher.service is enabled
+echo "2. Checking kbd-backlight-watcher.service enabled state:"
+systemctl --user is-enabled kbd-backlight-watcher.service 2>/dev/null || echo "   not found"
+echo ""
+
+# Check if kbd-backlight-watcher.service is active
+echo "3. Checking kbd-backlight-watcher.service status:"
+systemctl --user is-active kbd-backlight-watcher.service 2>/dev/null || echo "   not found"
+echo "   Full status:"
+systemctl --user status kbd-backlight-watcher.service 2>/dev/null | head -10
+echo ""
+
+# Check the WantedBy symlink
+echo "4. Checking WantedBy symlink exists:"
+ls -la ~/.config/systemd/user/graphical-session.target.wants/kbd-backlight-watcher.service 2>/dev/null || echo "   Symlink NOT found"
+echo ""
+
+# Check D-Bus environment
+echo "5. Checking D-Bus environment in systemd user session:"
+systemctl --user show-environment 2>/dev/null | grep -E "DISPLAY|DBUS_SESSION_BUS_ADDRESS" || echo "   D-Bus env NOT imported"
+echo ""
+
+# Check if keyboard backlight device exists
+echo "6. Checking keyboard backlight device:"
+ls -la /sys/class/leds/*kbd* 2>/dev/null || echo "   No keyboard backlight device found"
+echo ""
+
+echo "=== Diagnosis ==="
+echo ""
+
+TARGET_ACTIVE=$(systemctl --user is-active graphical-session.target 2>/dev/null)
+SERVICE_ENABLED=$(systemctl --user is-enabled kbd-backlight-watcher.service 2>/dev/null)
+SERVICE_ACTIVE=$(systemctl --user is-active kbd-backlight-watcher.service 2>/dev/null)
+DBUS_IMPORTED=$(systemctl --user show-environment 2>/dev/null | grep -c DBUS_SESSION_BUS_ADDRESS)
+
+if [ "$TARGET_ACTIVE" != "active" ]; then
+    echo "PROBLEM: graphical-session.target is NOT active!"
+    echo "  This means startx/.xinitrc is not starting it."
+    echo "  Fix: Add 'systemctl --user start graphical-session.target' to .xinitrc"
+    echo "  (after importing D-Bus environment)"
+fi
+
+if [ "$SERVICE_ENABLED" != "enabled" ]; then
+    echo "PROBLEM: kbd-backlight-watcher.service is NOT enabled!"
+    echo "  Fix: Run 'systemctl --user enable kbd-backlight-watcher.service'"
+fi
+
+if [ "$SERVICE_ACTIVE" != "active" ]; then
+    echo "PROBLEM: kbd-backlight-watcher.service is NOT running!"
+    echo "  If target is active and service is enabled, check service logs:"
+    echo "  journalctl --user -u kbd-backlight-watcher.service"
+fi
+
+if [ "$DBUS_IMPORTED" -eq 0 ]; then
+    echo "PROBLEM: DBUS_SESSION_BUS_ADDRESS not in systemd user environment!"
+    echo "  Fix: Ensure .xinitrc imports it with:"
+    echo "  systemctl --user import-environment DISPLAY DBUS_SESSION_BUS_ADDRESS"
+fi
+
+if [ "$TARGET_ACTIVE" = "active" ] && [ "$SERVICE_ENABLED" = "enabled" ] && [ "$SERVICE_ACTIVE" = "active" ] && [ "$DBUS_IMPORTED" -gt 0 ]; then
+    echo "All checks passed! The keyboard backlight OSD should work."
+    echo "Test by pressing Fn+Space on your keyboard."
+fi


### PR DESCRIPTION
## Summary

Fixes #71 — Fn+Space keyboard backlight works but dunst notification never appears.

**One-line fix in `.xinitrc`**: Start `graphical-session.target` after importing D-Bus environment.

## Root Cause

The keyboard backlight watcher service (`kbd-backlight-watcher.service`) has `WantedBy=graphical-session.target`, but **`graphical-session.target` was never activated**. 

Display managers (GDM, SDDM, LightDM) activate `graphical-session.target` automatically. But this setup uses `startx` with `.xinitrc`, which does **not** activate it. So the service was properly enabled via `systemctl --user enable`, but it never auto-started because the target it's wanted by was never reached.

Everything else (inotify watcher, D-Bus discovery, systemd service, OSD scripts) was already working correctly from PRs #77–#80. The only missing piece was this single `systemctl --user start` call.

## What Each Previous PR Fixed (and why notifications still didn't work)

| PR | What it did | Why notifications still didn't work |
|---|---|---|
| **#76** | Changed i3 binding from `$mod+Space` to `XF86KbdLightOnOff` (Fn-key) | Fn+Space is handled by firmware — X11 never receives the keypress, so i3 binding is ineffective |
| **#77** | Added `kbd-backlight-watcher.sh` daemon using `inotifywait` to monitor sysfs brightness changes, launched via i3's `exec_always` | The background subshell from `exec_always` lost `DBUS_SESSION_BUS_ADDRESS` |
| **#78** | Captured `DBUS_SESSION_BUS_ADDRESS` at watcher script startup and forwarded it to background subshell | Still launched via `exec_always` which has unreliable D-Bus env in subprocesses |
| **#79** | Moved watcher to a proper **systemd user service** (`kbd-backlight-watcher.service`) instead of `exec_always`. Added D-Bus address discovery with multiple fallbacks. | Service was `WantedBy=graphical-session.target` but that target was **never started** |
| **#80** | Added `systemctl --user import-environment` in `.xinitrc` to pass D-Bus address to systemd user session | D-Bus env was imported, but the target to pull in the service was still never started |

## The Fix (This PR)

```bash
# Added to .xinitrc after importing D-Bus environment:
systemctl --user start graphical-session.target
```

This is a standard practice for `startx`-based setups. The ordering in `.xinitrc` is now:

1. `dbus-launch` — creates the D-Bus session
2. `import-environment` — passes D-Bus address to systemd user session (from PR #80)
3. **`start graphical-session.target`** — activates the target, pulling in all services that are `WantedBy` it (including `kbd-backlight-watcher.service`) ← **this PR**
4. `exec i3` — starts i3 window manager

## How to Test

After pulling this change, **log out and log back in** (or reboot). Then:

```bash
# Verify graphical-session.target is active:
systemctl --user is-active graphical-session.target
# Expected: active

# Verify watcher service is running:
systemctl --user status kbd-backlight-watcher.service
# Expected: active (running)

# Or run the diagnostic script:
~/dotfiles/experiments/test-graphical-session-target.sh

# Then press Fn+Space — dunst OSD should appear!
```

## Quick Manual Fix (without re-login)

```bash
cd ~/dotfiles && git pull
systemctl --user import-environment DISPLAY DBUS_SESSION_BUS_ADDRESS XDG_CURRENT_DESKTOP
systemctl --user start graphical-session.target
# Press Fn+Space — OSD should now appear
```

## Changes

- `.xinitrc`: Added `systemctl --user start graphical-session.target` (4 lines with comments)
- `experiments/test-graphical-session-target.sh`: Diagnostic script to verify the fix