### PR TITLE
Fix dirty git tree after install.sh: stop regenerating detect-audio-keys.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/eg0rmaffin/vapor-rice-i3/issues/81
-Your prepared branch: issue-81-2582d9593892
-Your prepared working directory: /tmp/gh-issue-solver-1770463266229
-Your forked repository: konard/eg0rmaffin-vapor-rice-i3
-Original repository (upstream): eg0rmaffin/vapor-rice-i3
-
-Proceed.


### PR DESCRIPTION
## Summary

Fixes the bug reported in https://github.com/eg0rmaffin/vapor-rice-i3/issues/81#issuecomment-3864280460 where running `install.sh` leaves the dotfiles git tree dirty (modified `bin/detect-audio-keys.sh`).

## Root Cause

`scripts/audio_setup.sh` contained a **heredoc that overwrote** `bin/detect-audio-keys.sh` on every `install.sh` run. The embedded copy had stale `70%` volume, while the actual repo file was updated to `100%` by PR #86. This created a visible `git diff` after every install.

The script existed in **two places** — as a tracked file in the repo and as an inline heredoc in `audio_setup.sh`. Any edit to one was not reflected in the other, violating the declarative/idempotent principle.

## Fix

- Removed the 66-line heredoc from `scripts/audio_setup.sh`
- `bin/detect-audio-keys.sh` is now the **single source of truth** (tracked in git)
- `audio_setup()` now only ensures the file is executable and sets up the i3 config references
- All config setup (i3 include directive, autostart entry) is still handled, with idempotent `grep -q` guards

## Declarative & Idempotent

Yes — this PR ensures `install.sh` is fully declarative and idempotent:

- **No tracked files are modified** during install — `git status` stays clean
- **Config files** (PipeWire, WirePlumber) are deployed as **symlinks** pointing back to the repo
- **All scripts** (`detect-audio-keys.sh`, `audio-ensure-default.sh`, `audio-policy-check.sh`) are repo-tracked files, not generated
- Running `install.sh` multiple times produces the same result every time

## Audio Architecture (unchanged)

The existing audio policy from PRs #83-#86 is fully preserved:

```
App streams → [Virtual Output sink] → loopback → [physical device]
```

- Virtual sink is the single user-facing volume control
- Physical ALSA devices always at 100%
- Bluetooth stays in A2DP (no HSP/HFP profile switching)
- Device hot-plug redirects loopback, never touches app streams
- PipeWire is never restarted during install

## Test Plan

- [ ] Run `install.sh` — verify `git status` shows clean working tree afterward
- [ ] Verify audio keys (volume up/down/mute) still work
- [ ] Verify `audio-policy-check.sh` passes all checks
- [ ] Connect/disconnect Bluetooth headphones — verify apps keep playing

---

Fixes eg0rmaffin/vapor-rice-i3#81

🤖 Generated with [Claude Code](https://claude.com/claude-code)