### PR TITLE
🎨 Fix GTK3 dark fallback: set explicit Adwaita-dark alongside prefer-dark

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-25T18:26:46.377Z for PR creation at branch issue-101-9a0d28a99f10 for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/101

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-25T18:26:46.377Z for PR creation at branch issue-101-9a0d28a99f10 for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/101

--- a/install.sh
+++ b/install.sh
@@ -842,8 +842,13 @@ source ~/dotfiles/scripts/audio_policy.sh
 setup_audio_policy
 
 # ─── 🎨 Appearance policy (dark mode for browsers / portal / electron) ───
+# GTK4 apps respect color-scheme=prefer-dark, but GTK3 apps (e.g. blueman) do
+# not reliably interpret it and may fall back to light Adwaita. Setting
+# gtk-theme to Adwaita-dark removes that ambiguity for GTK3 while keeping
+# prefer-dark for portals / browsers / electron.
 if command -v gsettings >/dev/null && [ -n "$DBUS_SESSION_BUS_ADDRESS" ]; then
   gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
+  gsettings set org.gnome.desktop.interface gtk-theme 'Adwaita-dark'
 else
   echo -e "${YELLOW}⚠️ Skipping gsettings (no DBus session)${RESET}"
 fi


### PR DESCRIPTION
## Summary

This PR makes the dark-mode preference unambiguous for GTK3 apps so they render dark consistently with GTK4 apps under the startx + i3 + systemd-user-session model.

## Problem

With only:

```
gtk-theme   = Adwaita
color-scheme = prefer-dark
```

GTK4 apps respect the dark preference, but GTK3 apps (e.g. `blueman`) may fall back to **light Adwaita**.

### Root cause
GTK3 does not reliably interpret `color-scheme=prefer-dark` unless `gtk-application-prefer-dark-theme=1` is set or an explicit dark theme is selected.

## Fix

In `install.sh`, alongside the existing `color-scheme=prefer-dark`, also set:

```bash
gsettings set org.gnome.desktop.interface gtk-theme 'Adwaita-dark'
```

This is not a workaround — it removes the configuration ambiguity that GTK3 cannot resolve on its own, while keeping `prefer-dark` for portals / browsers / electron.

### Changes
- **`install.sh`**: Set `gtk-theme = Adwaita-dark` via `gsettings` after `color-scheme = prefer-dark`, guarded by the same `gsettings` + `DBUS_SESSION_BUS_ADDRESS` check.

## Test plan
- [ ] Run `install.sh`
- [ ] Verify `gsettings get org.gnome.desktop.interface gtk-theme` returns `'Adwaita-dark'`
- [ ] Verify `gsettings get org.gnome.desktop.interface color-scheme` returns `'prefer-dark'`
- [ ] Launch `blueman-manager` (GTK3) — verify it renders dark
- [ ] Launch a GTK4 app — verify it still renders dark
- [ ] Run on a session without DBus — verify the warning still fires and install doesn't fail

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)