### PR TITLE
🔐 Add explicit --repair-keyring flag for Arch pacman keyring recovery

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-22T10:29:08.457Z for PR creation at branch issue-109-ed8f5a85866e for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/109

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-22T10:29:08.457Z for PR creation at branch issue-109-ed8f5a85866e for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/109

--- a/experiments/test-arch-safety.sh
+++ b/experiments/test-arch-safety.sh
@@ -39,15 +39,18 @@ INSTALL_SH="../install.sh"
 # Count pacman -Syu (safe, should only be in perform_system_upgrade fallback)
 SAFE_SYNC=$(grep -c "pacman -Syu" "$INSTALL_SH" 2>/dev/null || echo "0")
 
-# Count pacman -Sy (excluding -Syu, comments, and string literals)
-# This should be 0 in the new design
-BARE_SY=$(grep -E "pacman -Sy[^u]|pacman -Sy$" "$INSTALL_SH" 2>/dev/null | grep -v "^#" | grep -v "# " | grep -v "'pacman" | wc -l | tr -d ' ')
+# Count pacman -Sy (excluding -Syu, comments, and string literals).
+# EXCEPTION: `pacman -Sy archlinux-keyring` is the documented, safe keyring-recovery
+# procedure (used by the --repair-keyring flag). It updates ONLY the keyring package
+# and is the standard Arch fix for a stale/broken trustdb, so it is intentionally
+# allowed here. Every OTHER bare -Sy is a partial-upgrade footgun and must stay at 0.
+BARE_SY=$(grep -E "pacman -Sy[^u]|pacman -Sy$" "$INSTALL_SH" 2>/dev/null | grep -v "^#" | grep -v "# " | grep -v "'pacman" | grep -v "archlinux-keyring" | wc -l | tr -d ' ')
 
 # Count pacman -Syy (should be 0)
 BARE_SYY=$(grep "pacman -Syy" "$INSTALL_SH" 2>/dev/null | wc -l | tr -d ' ' || echo "0")
 
 echo "  Safe -Syu calls: $SAFE_SYNC (inside fallback functions)"
-echo "  Bare -Sy calls: $BARE_SY (expected: 0 in offline-first design)"
+echo "  Bare -Sy calls: $BARE_SY (expected: 0; archlinux-keyring recovery excepted)"
 echo "  Bare -Syy calls: $BARE_SYY (expected: 0)"
 
 if [ "$BARE_SYY" -eq 0 ]; then
@@ -192,6 +195,12 @@ if grep -q "\-\-force-sync" "$INSTALL_SH"; then
     test_pass "--force-sync flag defined"
 else
     test_fail "--force-sync flag not found"
+fi
+
+if grep -q "\-\-repair-keyring" "$INSTALL_SH"; then
+    test_pass "--repair-keyring flag defined"
+else
+    test_fail "--repair-keyring flag not found"
 fi
 
 # ─────────────────────────────────────────────

--- a/experiments/test-repair-keyring.sh
+++ b/experiments/test-repair-keyring.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# ─────────────────────────────────────────────
+# Test suite for the --repair-keyring flag in install.sh
+#
+# Part A — STRUCTURAL checks (grep on install.sh): flag, function, dispatcher,
+#          offline-first guarantees (no --refresh-keys, no SigLevel tampering).
+#
+# Part B — BEHAVIORAL checks: actually run `install.sh --repair-keyring` with all
+#          privileged commands (sudo / pacman / pacman-key / pgrep / timedatectl)
+#          replaced by logging mocks, and assert that the script:
+#            1. repairs the keyring (offline reset + archlinux-keyring update),
+#            2. EXITS without continuing into the dotfiles install flow,
+#            3. refuses safely when a pacman/yay/makepkg process is running,
+#            4. still completes the offline repair when the online update fails.
+#
+# No root and no real pacman are required — everything is intercepted by mocks.
+#
+# Do not use `set -e`: we want every test to run even if an earlier one fails.
+
+GREEN="\033[0;32m"; RED="\033[0;31m"; CYAN="\033[0;36m"; YELLOW="\033[1;33m"; RESET="\033[0m"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+PASS=0
+FAIL=0
+test_pass() { echo -e "${GREEN}✅ PASS${RESET}: $1"; PASS=$((PASS + 1)); }
+test_fail() { echo -e "${RED}❌ FAIL${RESET}: $1"; FAIL=$((FAIL + 1)); }
+
+# assert_contains <description> <haystack> <needle>
+assert_contains() {
+    if echo "$2" | grep -qF -- "$3"; then test_pass "$1"; else test_fail "$1 (missing: '$3')"; fi
+}
+# assert_not_contains <description> <haystack> <needle>
+assert_not_contains() {
+    if echo "$2" | grep -qF -- "$3"; then test_fail "$1 (unexpectedly found: '$3')"; else test_pass "$1"; fi
+}
+# assert_eq <description> <expected> <actual>
+assert_eq() {
+    if [ "$2" = "$3" ]; then test_pass "$1"; else test_fail "$1 (expected='$2' actual='$3')"; fi
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Part A — Structural checks
+# ═════════════════════════════════════════════════════════════════════════════
+echo -e "${CYAN}── Part A: structural checks ──${RESET}"
+
+if grep -q "REPAIR_KEYRING=0" "$INSTALL_SH"; then
+    test_pass "REPAIR_KEYRING flag variable initialized"
+else
+    test_fail "REPAIR_KEYRING flag variable not found"
+fi
+
+if grep -q '"--repair-keyring" \]\] && REPAIR_KEYRING=1' "$INSTALL_SH"; then
+    test_pass "--repair-keyring parsed in argument loop"
+else
+    test_fail "--repair-keyring not parsed in argument loop"
+fi
+
+if grep -q "perform_keyring_repair()" "$INSTALL_SH"; then
+    test_pass "perform_keyring_repair() function defined"
+else
+    test_fail "perform_keyring_repair() function not found"
+fi
+
+if grep -q "check_explicit_keyring_repair()" "$INSTALL_SH"; then
+    test_pass "check_explicit_keyring_repair() dispatcher defined"
+else
+    test_fail "check_explicit_keyring_repair() dispatcher not found"
+fi
+
+# The dispatcher must be CALLED before the install flow starts (before the header
+# banner / multilib / mirrors). We approximate "before the flow" as: the call
+# appears before the deps install_list invocation.
+call_line=$(grep -n "^check_explicit_keyring_repair$" "$INSTALL_SH" | head -1 | cut -d: -f1)
+flow_line=$(grep -n 'install_list "\${deps\[@\]}"' "$INSTALL_SH" | head -1 | cut -d: -f1)
+if [ -n "$call_line" ] && [ -n "$flow_line" ] && [ "$call_line" -lt "$flow_line" ]; then
+    test_pass "Dispatcher called before the package install flow (line $call_line < $flow_line)"
+else
+    test_fail "Dispatcher not called before the package install flow (call=$call_line flow=$flow_line)"
+fi
+
+# The dispatcher must exit so it cannot fall through into the install flow.
+if grep -A6 "check_explicit_keyring_repair()" "$INSTALL_SH" | grep -q "exit 0"; then
+    test_pass "Dispatcher exits after repair (does not continue the install flow)"
+else
+    test_fail "Dispatcher does not exit after repair"
+fi
+
+# Offline-first guarantees explicitly required by the issue.
+if grep -A50 "perform_keyring_repair()" "$INSTALL_SH" | grep -q -- "--refresh-keys"; then
+    test_fail "perform_keyring_repair uses --refresh-keys (violates offline-first)"
+else
+    test_pass "perform_keyring_repair does NOT use --refresh-keys (offline-first)"
+fi
+
+# Only executable (non-comment) lines count — a comment documenting that we leave
+# SigLevel alone is fine; an actual SigLevel assignment in pacman.conf is not.
+if grep -v '^[[:space:]]*#' "$INSTALL_SH" | grep -q "SigLevel"; then
+    test_fail "install.sh modifies SigLevel (must not change signature policy)"
+else
+    test_pass "install.sh does not modify SigLevel (signature verification preserved)"
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Part B — Behavioral checks (mocked privileged commands)
+# ═════════════════════════════════════════════════════════════════════════════
+echo -e "${CYAN}── Part B: behavioral checks (mocked sudo/pacman/pgrep) ──${RESET}"
+
+MOCK_ROOT="$(mktemp -d)"
+trap 'rm -rf "$MOCK_ROOT"' EXIT
+MOCK_BIN="$MOCK_ROOT/bin"
+mkdir -p "$MOCK_BIN"
+CMD_LOG="$MOCK_ROOT/cmd.log"
+
+# sudo: log the invocation, then succeed — unless SUDO_FAIL_MATCH is set and the
+# command line matches it (used to simulate a failing online keyring update).
+cat > "$MOCK_BIN/sudo" <<'MOCK'
+#!/bin/bash
+echo "sudo $*" >> "$CMD_LOG"
+if [ -n "$SUDO_FAIL_MATCH" ] && echo "$*" | grep -q -- "$SUDO_FAIL_MATCH"; then
+    exit 1
+fi
+exit 0
+MOCK
+
+# pgrep: report "no process" (exit 1) unless PGREP_FOUND=1 (simulate live txn).
+cat > "$MOCK_BIN/pgrep" <<'MOCK'
+#!/bin/bash
+echo "pgrep $*" >> "$CMD_LOG"
+[ "${PGREP_FOUND:-0}" = "1" ] && exit 0
+exit 1
+MOCK
+
+# timedatectl: present so the best-effort NTP branch is exercised.
+cat > "$MOCK_BIN/timedatectl" <<'MOCK'
+#!/bin/bash
+echo "timedatectl $*" >> "$CMD_LOG"
+exit 0
+MOCK
+
+chmod +x "$MOCK_BIN"/sudo "$MOCK_BIN"/pgrep "$MOCK_BIN"/timedatectl
+
+# run_repair <pgrep_found> <sudo_fail_match>  → sets globals: RC, OUT, LOG
+run_repair() {
+    : > "$CMD_LOG"
+    env "PATH=$MOCK_BIN:$PATH" "CMD_LOG=$CMD_LOG" \
+        "PGREP_FOUND=$1" "SUDO_FAIL_MATCH=$2" \
+        bash "$INSTALL_SH" --repair-keyring > "$MOCK_ROOT/out.log" 2>&1
+    RC=$?
+    OUT="$(cat "$MOCK_ROOT/out.log")"
+    LOG="$(cat "$CMD_LOG")"
+}
+
+# ── Scenario 1: happy path ───────────────────────────────────────────────────
+echo -e "${YELLOW}Scenario 1: happy path (no running process, online update OK)${RESET}"
+run_repair "0" ""
+assert_eq          "exits 0 on success" "0" "$RC"
+assert_contains    "announces explicit repair" "$OUT" "Explicit pacman keyring repair requested"
+assert_contains    "reports keyring repaired + keyring updated" "$OUT" "Pacman keyring repaired and archlinux-keyring updated"
+assert_not_contains "does NOT print the install header (early exit)" "$OUT" "Installing your dotfiles"
+assert_contains    "runs offline reset (rm gnupg dir)" "$LOG" "rm -rf /etc/pacman.d/gnupg"
+assert_contains    "runs pacman-key --init" "$LOG" "pacman-key --init"
+assert_contains    "runs pacman-key --populate archlinux" "$LOG" "pacman-key --populate archlinux"
+assert_contains    "updates archlinux-keyring online" "$LOG" "pacman -Sy --noconfirm archlinux-keyring"
+assert_contains    "enables NTP best-effort" "$LOG" "timedatectl set-ntp true"
+assert_not_contains "does NOT install the dotfiles deps (no xorg-server)" "$LOG" "xorg-server"
+assert_not_contains "does NOT run a full system upgrade" "$LOG" "pacman -Syu"
+
+# ── Scenario 2: a package manager is running → safe abort ────────────────────
+echo -e "${YELLOW}Scenario 2: pacman/yay/makepkg running → refuse and exit 1${RESET}"
+run_repair "1" ""
+assert_eq          "exits 1 when a transaction may be active" "1" "$RC"
+assert_contains    "warns about the running process" "$OUT" "Another package manager process is running"
+assert_not_contains "does NOT touch the keyring (no pacman-key)" "$LOG" "pacman-key"
+assert_not_contains "does NOT delete the gnupg dir" "$LOG" "rm -rf /etc/pacman.d/gnupg"
+
+# ── Scenario 3: online update fails → offline repair still completes ─────────
+echo -e "${YELLOW}Scenario 3: online archlinux-keyring update fails → offline repair still OK${RESET}"
+run_repair "0" "archlinux-keyring"
+assert_eq          "still exits 0 (offline reset is the deterministic core)" "0" "$RC"
+assert_contains    "still runs the offline reset" "$LOG" "pacman-key --init"
+assert_contains    "reports the offline reset was applied" "$OUT" "offline reset applied"
+assert_not_contains "still does NOT continue the install flow" "$OUT" "Installing your dotfiles"
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Summary
+# ═════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "═══════════════════════════════════════════"
+echo -e "Tests passed: ${GREEN}$PASS${RESET}"
+echo -e "Tests failed: ${RED}$FAIL${RESET}"
+echo "═══════════════════════════════════════════"
+[ "$FAIL" -eq 0 ]

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,8 @@ declare -a REPO_MISSING_LOCAL_INSTALLED=()
 # Override: pass --force-sync or set FORCE_SYNC=1
 # NEW: --upgrade flag to force full system upgrade
 # NEW: --no-upgrade flag to skip upgrade even when sync is needed
+# NEW: --repair-keyring flag — emergency: repair pacman keyring state and EXIT
+#      (does NOT continue into the dotfiles install flow). See check_explicit_keyring_repair.
 SYNC_COOLDOWN=3600  # seconds (1 hour)
 SYNC_STAMP="$HOME/.cache/vapor-rice/last-sync"
 UPGRADE_STAMP="$HOME/.cache/vapor-rice/last-upgrade"
@@ -27,10 +29,12 @@ UPGRADE_STAMP="$HOME/.cache/vapor-rice/last-upgrade"
 FORCE_SYNC=0
 FORCE_UPGRADE=0
 NO_UPGRADE=0
+REPAIR_KEYRING=0
 for arg in "$@"; do
     [[ "$arg" == "--force-sync" ]] && FORCE_SYNC=1
     [[ "$arg" == "--upgrade" ]] && FORCE_UPGRADE=1
     [[ "$arg" == "--no-upgrade" ]] && NO_UPGRADE=1
+    [[ "$arg" == "--repair-keyring" ]] && REPAIR_KEYRING=1
 done
 
 needs_sync() {
@@ -67,6 +71,65 @@ repair_keyring_offline() {
     sudo pacman-key --populate archlinux
 
     echo -e "${GREEN}✅ Keyring repaired (offline)${RESET}"
+}
+
+# ─────────────────────────────────────────────
+# 🔐 Explicit keyring repair (emergency manual command — triggered by --repair-keyring)
+# Deterministic, OFFLINE-FIRST recovery for the classic Arch "keyring / trustdb is
+# stale or broken" failures that block any upgrade:
+#   - invalid or corrupted package (PGP signature)
+#   - signature is marginal trust
+#   - unknown trust
+#   - keyring not initialized
+# It does NOT use --refresh-keys (slow/flaky) and does NOT touch SigLevel or disable
+# signature verification — package signature checking stays fully intact.
+perform_keyring_repair() {
+    echo -e "${CYAN}🔐 Explicit pacman keyring repair requested...${RESET}"
+
+    # ─── Safety: never repair under a live package transaction ───
+    # Reinitializing the keyring while pacman/yay/makepkg is mid-transaction can
+    # corrupt state. If a real process is running, refuse and bail out — we
+    # deliberately do NOT blindly delete the pacman db lock.
+    local proc running=""
+    for proc in pacman yay makepkg; do
+        if pgrep -x "$proc" >/dev/null 2>&1; then
+            running="$proc"
+            break
+        fi
+    done
+    if [ -n "$running" ]; then
+        echo -e "${RED}❌ Another package manager process is running: ${running}${RESET}"
+        echo -e "${YELLOW}   Refusing to repair the keyring while a transaction may be active.${RESET}"
+        echo -e "${YELLOW}   Wait for it to finish (or close it), then retry: ./install.sh --repair-keyring${RESET}"
+        exit 1
+    fi
+
+    # Make sure system time is sane enough for signature validity windows.
+    # Best-effort: enable NTP if timedatectl is available (never fatal).
+    if command -v timedatectl >/dev/null 2>&1; then
+        sudo timedatectl set-ntp true 2>/dev/null || true
+    fi
+
+    # Full offline reset from the installed archlinux-keyring package
+    # (rm gnupg dir, pacman-key --init, pacman-key --populate archlinux).
+    repair_keyring_offline
+
+    # Refresh databases and update ONLY the archlinux-keyring package so the
+    # trustdb is rebuilt from the newest keyring. This is the single online step
+    # and is best-effort: the offline reset above is the deterministic core, so a
+    # network/mirror/lock failure here must NOT undo the repair we just did.
+    if sudo pacman -Sy --noconfirm archlinux-keyring; then
+        # Repopulate again so the trustdb reflects the just-updated keyring.
+        sudo pacman-key --populate archlinux
+        echo -e "${GREEN}✅ Pacman keyring repaired and archlinux-keyring updated${RESET}"
+    else
+        echo -e "${YELLOW}⚠️  Could not update archlinux-keyring online (network, mirror, or pacman lock).${RESET}"
+        echo -e "${YELLOW}   The offline keyring reset already completed — core trust state is restored.${RESET}"
+        echo -e "${GREEN}✅ Pacman keyring repaired (offline reset applied)${RESET}"
+    fi
+
+    echo -e "${CYAN}You can now retry:${RESET}"
+    echo -e "  yay -Syu"
 }
 
 # Legacy function for --upgrade flag (explicit user request)
@@ -113,6 +176,21 @@ check_explicit_upgrade() {
         return 0
     fi
     return 1
+}
+
+# Check if explicit keyring repair was requested via the --repair-keyring flag.
+# When set, repair the keyring and EXIT immediately. This must NOT continue into
+# the dotfiles install flow (packages, symlinks, audio, hardware, etc.) — it does
+# exactly one thing: repair Arch pacman keyring state.
+#
+# Combined-flag note: if --repair-keyring is passed together with other flags
+# (e.g. --upgrade), the keyring is repaired and the script exits regardless.
+# This explicit "repair and exit" behavior is intentional for the first version.
+check_explicit_keyring_repair() {
+    if [[ "$REPAIR_KEYRING" -eq 1 ]]; then
+        perform_keyring_repair
+        exit 0
+    fi
 }
 
 # ─────────────────────────────────────────────
@@ -353,6 +431,13 @@ install_list() {
     echo -e "${RED}Please check the pacman output above and resolve manually.${RESET}"
     return 1
 }
+
+# ─────────────────────────────────────────────
+# 🔐 Explicit keyring repair short-circuit (emergency manual command)
+# MUST run before ANY install-flow side effects (multilib, mirrors, packages,
+# symlinks, audio, hardware…). If --repair-keyring was passed, this repairs the
+# pacman keyring and exits 0 — doing exactly one thing and nothing else.
+check_explicit_keyring_repair
 
 # ─────────────────────────────────────────────
 # 🚀 Шапка


### PR DESCRIPTION
## 🔐 Add explicit `--repair-keyring` flag for Arch pacman keyring recovery

Fixes eg0rmaffin/vapor-rice-i3#109

Adds a manual, emergency command — `./install.sh --repair-keyring` — that recovers
from the classic Arch pacman PGP / marginal-trust failures that block any upgrade:

```
error: <pkg>: signature from "…" is marginal trust
error: failed to commit transaction (invalid or corrupted package (PGP signature))
error: key "…" could not be looked up remotely
```

It **repairs the keyring and then exits 0** — it never continues into the dotfiles
install flow (no package installs, symlinks, audio, or hardware setup). It does
**exactly one thing**.

### What it does (deterministic, offline-first)

1. **Refuses to run during a live transaction** — if `pacman`/`yay`/`makepkg` is
   running, it warns and exits `1` rather than reinitializing the keyring underneath
   an in-flight transaction.
2. **Best-effort NTP** — `timedatectl set-ntp true` (never fatal) so the clock is
   sane for signature validity windows.
3. **Offline reset** — reuses the existing `repair_keyring_offline()`:
   `rm -rf /etc/pacman.d/gnupg` → `pacman-key --init` → `pacman-key --populate archlinux`.
4. **Single online step (best-effort)** — `pacman -Sy --noconfirm archlinux-keyring`
   then `pacman-key --populate archlinux` again, rebuilding the trustdb from the newest
   keyring. If the network/mirror/lock fails here it does **not** undo the offline reset,
   so the core trust state is still restored and the command still exits `0`.

### Constraints honored (from the issue)

- ❌ **No `--refresh-keys`** — slow, flaky, and non-deterministic. Repair stays
  offline-first.
- ❌ **No `SigLevel` change / no disabling signature checking** — package signature
  verification stays fully intact. `/etc/pacman.conf` is never touched.
- ✅ **Repair-and-exit regardless of other flags** — if combined with e.g. `--upgrade`,
  the keyring is repaired and the script exits. This is the intended first-version
  behavior.

### Design decision: dispatcher placement

`check_explicit_keyring_repair` is invoked as the **first top-level statement after
argument parsing**, before the header banner / multilib / reflector mirror management /
package installs. Rationale:

- The issue requires the command to "do exactly one thing" and not run the install flow.
  Placing it early guarantees **zero install-flow side effects** (it short-circuits
  before reflector, which needs network and can take ~1 min — undesirable during an
  emergency repair).
- The existing `check_explicit_upgrade` call (which sits later, after mirror management)
  is left **untouched** to avoid any regression to `--upgrade` behavior.

### Reproducing the original problem

Before this change there was no way to repair the keyring without running the full
installer. To see the new behavior end-to-end without root or a real pacman, the test
suite intercepts every privileged command with logging mocks:

```bash
bash experiments/test-repair-keyring.sh
```

### Automated tests

**`experiments/test-repair-keyring.sh`** — 27 checks, structural + behavioral
(mocked `sudo`/`pacman`/`pacman-key`/`pgrep`/`timedatectl`):

- **Happy path** → exits `0`, runs the offline reset + online `archlinux-keyring`
  update, and does **not** print the install header or install dotfiles deps
  (no `xorg-server`, no `pacman -Syu`).
- **Live transaction** (`pgrep` finds `pacman`) → exits `1`, never touches the keyring.
- **Online update fails** → still exits `0`; the deterministic offline reset is applied.
- Structural guarantees: flag var + parser line, function + dispatcher exist, dispatcher
  is called **before** the install flow and **exits**, **no `--refresh-keys`**, and
  **no `SigLevel`** modification in executable lines.

**`experiments/test-arch-safety.sh`** — adds an assertion that `--repair-keyring` exists,
and updates the offline-first "no bare `pacman -Sy`" rule to **except** the one
documented, safe `pacman -Sy archlinux-keyring` keyring-recovery call (every *other*
bare `-Sy` is still blocked as a partial-upgrade footgun).

### Test results

```
test-repair-keyring.sh   → 27 passed, 0 failed (exit 0)
test-arch-safety.sh      → 21 passed, 0 failed (exit 0)
All 10 experiments/test-*.sh suites pass
shellcheck install.sh    → no new warnings (only pre-existing SC1090/SC2034)
bash -n install.sh       → SYNTAX OK
```

### Usage

```bash
# Emergency: pacman/yay fails with PGP / marginal-trust errors
./install.sh --repair-keyring
# → repairs keyring, exits, then:
yay -Syu
```
