### PR TITLE
📸 Fix Flameshot screenshot capture on Arch Linux X11 (useX11LegacyScreenshot)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-02T22:18:24.001Z for PR creation at branch issue-111-abe1c2fe4be0 for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/111

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-02T22:18:24.001Z for PR creation at branch issue-111-abe1c2fe4be0 for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/111

--- a/experiments/test_flameshot_patch.sh
+++ b/experiments/test_flameshot_patch.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Test harness for the idempotent Flameshot INI patch used in install.sh.
+# Verifies: no duplicate [General], no duplicate key, value coercion to true,
+# preservation of unrelated settings, and idempotency across repeated runs.
+set -e
+
+patch() {
+  local FLAMESHOT_INI="$1"
+  mkdir -p "$(dirname "$FLAMESHOT_INI")"
+  touch "$FLAMESHOT_INI"
+  awk '
+    BEGIN { in_general = 0; done = 0; general_seen = 0 }
+    /^\[/ {
+        if (in_general && !done) { print "useX11LegacyScreenshot=true"; done = 1 }
+        in_general = ($0 == "[General]")
+        if (in_general) general_seen = 1
+        print
+        next
+    }
+    {
+        if (in_general && $0 ~ /^useX11LegacyScreenshot[[:space:]]*=/) {
+            print "useX11LegacyScreenshot=true"
+            done = 1
+            next
+        }
+        print
+    }
+    END {
+        if (in_general && !done) { print "useX11LegacyScreenshot=true"; done = 1 }
+        if (!general_seen) {
+            if (NR > 0) print ""
+            print "[General]"
+            print "useX11LegacyScreenshot=true"
+        }
+    }
+  ' "$FLAMESHOT_INI" > "$FLAMESHOT_INI.tmp" && mv "$FLAMESHOT_INI.tmp" "$FLAMESHOT_INI"
+}
+
+check() {
+  local name="$1" file="$2"
+  # Must have exactly one [General], exactly one useX11LegacyScreenshot=true
+  local gcount kcount tcount
+  gcount=$(grep -c '^\[General\]$' "$file" || true)
+  kcount=$(grep -c '^useX11LegacyScreenshot=' "$file" || true)
+  tcount=$(grep -c '^useX11LegacyScreenshot=true$' "$file" || true)
+  if [ "$gcount" != "1" ] || [ "$kcount" != "1" ] || [ "$tcount" != "1" ]; then
+    echo "FAIL [$name]: [General]=$gcount key=$kcount true=$tcount"
+    echo "----- file -----"; cat "$file"; echo "----------------"
+    return 1
+  fi
+  echo "PASS [$name]"
+}
+
+run_case() {
+  local name="$1" content="$2"; shift 2
+  local d; d=$(mktemp -d)
+  local f="$d/.config/flameshot/flameshot.ini"
+  mkdir -p "$(dirname "$f")"
+  printf '%s' "$content" > "$f"
+  patch "$f"; check "$name (1st)" "$f"
+  # idempotency: run twice more, output must be byte-identical
+  cp "$f" "$f.after1"
+  patch "$f"; patch "$f"
+  if ! diff -q "$f.after1" "$f" >/dev/null; then
+    echo "FAIL [$name]: not idempotent"; diff "$f.after1" "$f"; return 1
+  fi
+  check "$name (idempotent)" "$f"
+  # extra assertions
+  for pat in "$@"; do
+    if ! grep -qF "$pat" "$f"; then echo "FAIL [$name]: missing preserved line '$pat'"; cat "$f"; return 1; fi
+  done
+  rm -rf "$d"
+}
+
+# 1. Empty / non-existent file
+run_case "empty" ""
+
+# 2. No [General] section, other sections present (preserve them)
+run_case "no-general" $'[Shortcuts]\nTYPE_COPY=Return\n' "[Shortcuts]" "TYPE_COPY=Return"
+
+# 3. [General] exists without the key, plus unrelated keys (preserve)
+run_case "general-no-key" $'[General]\ndisabledTrayIcon=false\nsavePath=/home/x/Pictures\n' "disabledTrayIcon=false" "savePath=/home/x/Pictures"
+
+# 4. Key already present but wrong value -> coerce to true
+run_case "wrong-value" $'[General]\nuseX11LegacyScreenshot=false\ncontrastOpacity=100\n' "contrastOpacity=100"
+
+# 5. Key already true (no-op)
+run_case "already-true" $'[General]\nuseX11LegacyScreenshot=true\n'
+
+# 6. [General] not last: another section after it, key must land in General
+run_case "general-then-other" $'[General]\nfoo=bar\n\n[Shortcuts]\nTYPE_COPY=Return\n' "foo=bar" "[Shortcuts]" "TYPE_COPY=Return"
+
+# 7. Section before General, General has key wrong value
+run_case "other-then-general" $'[Shortcuts]\nTYPE_COPY=Return\n\n[General]\nuseX11LegacyScreenshot=0\nsavePath=/x\n' "[Shortcuts]" "savePath=/x"
+
+echo "ALL TESTS PASSED"

--- a/install.sh
+++ b/install.sh
@@ -801,6 +801,45 @@ mkdir -p ~/.config/rofi
 ln -sf ~/dotfiles/rofi/config.rasi ~/.config/rofi/config.rasi
 echo -e "${GREEN}✅ Rofi config linked${RESET}"
 
+# 📸 Flameshot (screenshot backend)
+# On Arch + X11/i3 Flameshot may try the Wayland screenshot portal and hang with
+# "screenshot portal retry after 30 sec". Force the legacy X11 backend so that
+# `flameshot gui` / `flameshot screen` (used by ~/dotfiles/bin/screenshot.sh) work.
+# The .ini is owned/rewritten by Flameshot at runtime, so we patch it idempotently
+# in place instead of symlinking — preserving any unrelated user settings.
+echo -e "${CYAN}📸 Ensuring Flameshot uses the X11 legacy screenshot backend...${RESET}"
+FLAMESHOT_INI="$HOME/.config/flameshot/flameshot.ini"
+mkdir -p "$(dirname "$FLAMESHOT_INI")"
+touch "$FLAMESHOT_INI"
+awk '
+    BEGIN { in_general = 0; done = 0; general_seen = 0 }
+    /^\[/ {
+        # Leaving a section: if we were in [General] but never found the key, add it.
+        if (in_general && !done) { print "useX11LegacyScreenshot=true"; done = 1 }
+        in_general = ($0 == "[General]")
+        if (in_general) general_seen = 1
+        print
+        next
+    }
+    {
+        if (in_general && $0 ~ /^useX11LegacyScreenshot[[:space:]]*=/) {
+            print "useX11LegacyScreenshot=true"
+            done = 1
+            next
+        }
+        print
+    }
+    END {
+        if (in_general && !done) { print "useX11LegacyScreenshot=true"; done = 1 }
+        if (!general_seen) {
+            if (NR > 0) print ""
+            print "[General]"
+            print "useX11LegacyScreenshot=true"
+        }
+    }
+' "$FLAMESHOT_INI" > "$FLAMESHOT_INI.tmp" && mv "$FLAMESHOT_INI.tmp" "$FLAMESHOT_INI"
+echo -e "${GREEN}✅ Flameshot X11 legacy screenshot backend enabled${RESET}"
+
 # 🟣 Discord Proxy
 echo -e "${CYAN}🔧 Linking Discord Proxy...${RESET}"
 


### PR DESCRIPTION
## Summary

Fixes Flameshot screenshot capture on Arch Linux + X11/i3 (issue #111).

On this machine Flameshot starts and shows a tray icon, but `flameshot gui` hangs/fails with:

```
screenshot portal retry after 30 sec
```

This happens because Flameshot tries the Wayland screenshot **portal** even though the session is X11. The fix forces the legacy X11 screenshot backend by setting `useX11LegacyScreenshot=true` in the effective config.

## What changed

`install.sh` now patches `~/.config/flameshot/flameshot.ini` idempotently during the normal `./install.sh` flow, in the existing symlinks/config section (right after the Rofi config block, following repo conventions).

The `.ini` is **not** symlinked because Flameshot rewrites this file at runtime; instead it is patched in place with a small `awk` script that:

- ensures exactly one `[General]` section (no duplication on rerun);
- ensures exactly one `useX11LegacyScreenshot=true` (no duplication on rerun);
- coerces the key to `true` if it already exists with another value;
- preserves all unrelated existing Flameshot settings (`savePath`, shortcuts, etc.).

Flameshot itself was already in the pacman `deps` list, and `xclip` is kept. No new screenshot tools, no global portal changes, and the existing i3 keybindings / `bin/screenshot.sh` workflow are untouched.

## Reproduction / validation

After rerunning the normal flow:

```bash
./install.sh
```

Session type is X11:

```bash
echo "$XDG_SESSION_TYPE"   # x11
```

Effective Flameshot setting:

```bash
grep -E '^\[General\]|^useX11LegacyScreenshot=' ~/.config/flameshot/flameshot.ini
```

```
[General]
useX11LegacyScreenshot=true
```

Selection UI opens normally:

```bash
pkill flameshot || true
flameshot &
flameshot gui
```

## Tests

`experiments/test_flameshot_patch.sh` exercises the patch against 7 scenarios (empty file, no `[General]`, `[General]` without the key, wrong value, already-true, `[General]` followed by other sections, other section before `[General]`) and asserts idempotency (byte-identical output across repeated runs) plus preservation of unrelated lines. All pass:

```
ALL TESTS PASSED
```

## Acceptance criteria

- [x] `./install.sh` remains idempotent
- [x] Existing dotfiles structure/conventions preserved
- [x] Existing unrelated Flameshot config preserved
- [x] Existing screenshot/keybinding logic not broken
- [x] `flameshot gui` no longer fails with `screenshot portal retry after 30 sec` on Arch X11
- [x] No global portal hacks
- [x] No replacement of Flameshot with another screenshot tool

Closes #111
