### PR TITLE
Brightness UX: 10% step, OSD popup, instant i3blocks update

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-11T19:28:16.692Z for PR creation at branch issue-115-f62f52f70149 for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/115

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-11T19:28:16.692Z for PR creation at branch issue-115-f62f52f70149 for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/115

--- a/bin/brightness.sh
+++ b/bin/brightness.sh
@@ -60,8 +60,8 @@ MAX_BRIGHTNESS=$(cat "$BACKLIGHT_DIR/$BACKLIGHT_DEVICE/max_brightness")
 # Текущая яркость
 CURRENT=$(cat "$BRIGHTNESS_FILE")
 
-# Шаг изменения (5% от максимума)
-STEP=$((MAX_BRIGHTNESS / 20))
+# Шаг изменения (10% от максимума)
+STEP=$((MAX_BRIGHTNESS / 10))
 [ $STEP -lt 1 ] && STEP=1
 
 case "$1" in
@@ -84,3 +84,12 @@ case "$1" in
         exit 1
         ;;
 esac
+
+# ─── OSD + instant i3blocks update ───
+PERCENT=$((NEW * 100 / MAX_BRIGHTNESS))
+OSD_LIB="$HOME/dotfiles/scripts/osd/osd-panel.sh"
+if [ -f "$OSD_LIB" ] && command -v notify-send >/dev/null; then
+    . "$OSD_LIB"
+    osd_show_progress "brightness" "$OSD_ID_BRIGHTNESS" "🔆" "Brightness ${PERCENT}%" "$PERCENT"
+fi
+pkill -RTMIN+10 i3blocks 2>/dev/null || true

--- a/bin/brightness.sh
+++ b/bin/brightness.sh
@@ -90,6 +90,6 @@ PERCENT=$((NEW * 100 / MAX_BRIGHTNESS))
 OSD_LIB="$HOME/dotfiles/scripts/osd/osd-panel.sh"
 if [ -f "$OSD_LIB" ] && command -v notify-send >/dev/null; then
     . "$OSD_LIB"
-    osd_show_progress "brightness" "$OSD_ID_BRIGHTNESS" "🔆" "Brightness ${PERCENT}%" "$PERCENT"
+    osd_show_progress "brightness" "$OSD_ID_BRIGHTNESS" "🔆" "Brightness ${PERCENT}%" "$PERCENT" || true
 fi
 pkill -RTMIN+10 i3blocks 2>/dev/null || true

--- a/i3blocks/config
+++ b/i3blocks/config
@@ -17,6 +17,7 @@ color=#f1fa8c
 [brightness]
 command=~/dotfiles/i3blocks/brightness
 interval=5
+signal=10
 color=#50fa7b
 
 [network]


### PR DESCRIPTION
Closes #115

## Changes
1. **`bin/brightness.sh`**
   - Step changed from 5% (`MAX_BRIGHTNESS / 20`) to 10% (`MAX_BRIGHTNESS / 10`) so each press crosses a visible EC brightness level.
   - After a successful `up`/`down` write, show the vaporwave OSD progress popup (reusing `osd_show_progress` / `OSD_ID_BRIGHTNESS=421` from `scripts/osd/osd-panel.sh`) and signal i3blocks (`pkill -RTMIN+10 i3blocks`) for an instant bar update.
   - The `command -v notify-send` guard and `|| true` on `pkill` keep the script exiting 0 in a bare TTY (no X / dunst / i3blocks) under `set -e`.
2. **`i3blocks/config`**: added `signal=10` to the `[brightness]` block, keeping `interval=5` as a fallback poll for external changes.

## Untouched (per issue)
Device detection/priority logic, the 83DH kernel-param guard, `scripts/osd/osd-panel.sh`, volume/kbd-backlight OSD, and `install.sh`.

## Verification
- `bash -n bin/brightness.sh` → passes
- `grep -c "signal=10" i3blocks/config` → 1
- Tail snippet (OSD + pkill) exits 0 with no `notify-send`/i3blocks present
- With `max_brightness=800`, one press changes brightness by 80 units (10%)

## Test plan (requires human on 83DH hardware)
- Press XF86MonBrightnessUp/Down: panel visibly changes on every press, vaporwave OSD popup appears, i3blocks updates instantly.
- Hold key: graceful degradation via `--replace-id`, no notification spam.