### PR TITLE
Dark theme: close the Qt channel + document the delivery matrix

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-12T05:55:17.923Z for PR creation at branch issue-117-520764cc7d2f for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/117

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-12T05:55:17.923Z for PR creation at branch issue-117-520764cc7d2f for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/117

--- a/.xinitrc
+++ b/.xinitrc
@@ -6,6 +6,13 @@ fi
 
 export GTK_THEME=catppuccin-mocha-mauve-standard+default
 export GTK_ICON_THEME=Chicago95
+
+# ─── Qt platform theme (dark) ───
+# System-linked Qt apps (flameshot, future qbittorrent/OBS) don't read gsettings.
+# qt6ct provides the dark Fusion palette (~/.config/qt6ct/qt6ct.conf, symlinked by
+# install.sh). One value per session: qt6ct plugin themes Qt6 apps; Qt5 stragglers
+# fall back gracefully (qt5ct installed for anyone who prefers to flip this to qt5ct).
+export QT_QPA_PLATFORMTHEME=qt6ct
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 

--- a/install.sh
+++ b/install.sh
@@ -631,8 +631,10 @@ deps=(
     	swappy
     	swaybg             # фон
     	xdg-desktop-portal
-        xdg-desktop-portal-wlr
-        xdg-desktop-portal-gtk #это x вещь для скриншера вроде
+        xdg-desktop-portal-gtk # X11/i3 portal backend (screenshot + org.freedesktop.appearance dark scheme)
+        # ─── Qt platform theming (dark) ───
+        qt6ct                  # Qt6 platform theme (flameshot, future qbittorrent/OBS) → dark Fusion palette
+        qt5ct                  # Qt5 stragglers (see note near QT_QPA_PLATFORMTHEME in .xinitrc)
 )
 
 # было: явный for-цикл; стало: вызов хелпера
@@ -985,6 +987,16 @@ if command -v gsettings >/dev/null && [ -n "$DBUS_SESSION_BUS_ADDRESS" ]; then
 else
   echo -e "${YELLOW}⚠️ Skipping gsettings (no DBus session)${RESET}"
 fi
+
+# ─── Qt dark theme (4th delivery channel — see nondeclarative/dark-theme.md) ───
+# GTK/portal/gsettings above cover GTK + org.freedesktop.appearance consumers.
+# Qt apps linked against the system Qt (flameshot, future qbittorrent/OBS) do not
+# read gsettings; they need a Qt platform theme. qt6ct + Fusion + dark palette,
+# selected via QT_QPA_PLATFORMTHEME (exported in .xinitrc before `exec i3`).
+echo -e "${CYAN}🎨 Linking Qt dark theme (qt6ct)...${RESET}"
+mkdir -p ~/.config/qt6ct
+ln -sf ~/dotfiles/qt6ct/qt6ct.conf ~/.config/qt6ct/qt6ct.conf
+echo -e "${GREEN}✅ qt6ct.conf linked${RESET}"
 
 # ─────────────────────────────────────────────
 # 🔵 Bluetooth

--- a/nondeclarative/dark-theme.md
+++ b/nondeclarative/dark-theme.md
@@ -1,0 +1,36 @@
+# Dark theme delivery matrix
+
+Dark theme on this rice is delivered through **four independent channels**. There is
+no single global "dark mode" switch on X11/i3 — each toolkit/family reads its own
+source of truth. This table is the answer to any future *"why is app X light?"*.
+
+| Channel | Mechanism | Config that serves it | Example app | Status |
+|---|---|---|---|---|
+| GTK3 | `gtk-theme=Adwaita-dark` (gsettings) | `install.sh` appearance block (`gsettings set … gtk-theme 'Adwaita-dark'`) | blueman, pavucontrol | ✅ |
+| GTK4 / libadwaita | `color-scheme=prefer-dark` (gsettings) | `install.sh` appearance block (`gsettings set … color-scheme 'prefer-dark'`) | nautilus-class GTK4 apps | ✅ |
+| Portal (`org.freedesktop.appearance`) | `xdg-desktop-portal` + `-gtk` backend exposes `color-scheme` | `xdg-desktop-portal` + `xdg-desktop-portal-gtk` (packages) | Firefox, Chromium, Electron | ✅ (`ReadOne` → `v u 1`) |
+| Qt (system-linked) | `QT_QPA_PLATFORMTHEME=qt6ct` → Fusion + dark palette | `qt6ct/qt6ct.conf` (symlinked) + env in `.xinitrc` | flameshot, future qbittorrent/OBS | ✅ |
+
+## Why four channels
+
+- **gsettings** covers GTK3 and GTK4/libadwaita, but each reads a *different* key
+  (`gtk-theme` vs `color-scheme`) — both are set.
+- The **portal** re-exports `color-scheme` over D-Bus for sandboxed / non-GTK
+  consumers (browsers, Electron). Only the `-gtk` portal backend is installed;
+  `xdg-desktop-portal-wlr` is a wlroots/Wayland backend and is **not** used on
+  X11/i3.
+- **Qt** ignores gsettings entirely. `qt6ct` provides a platform theme; it is
+  selected per-session via `QT_QPA_PLATFORMTHEME=qt6ct` exported in `.xinitrc`
+  before `exec i3`. `qt5ct` is installed for any Qt5 straggler — flip the env var
+  to `qt5ct` if you ever need Qt5-only theming (one value per session).
+
+## The bundled-Qt rule
+
+Apps that **bundle their own Qt** are out of reach of system theming — they load
+their own `libQt6*` and `qt.conf` and ignore `QT_QPA_PLATFORMTHEME`:
+
+- **telegram-desktop** — theme managed in-app (Settings → Chat Settings).
+- **happ-desktop-bin** — ships `/opt/happ/lib/libQt6*` + own `qt.conf`; theme
+  managed in-app.
+
+Rule of thumb: **bundled Qt = in-app setting.** Don't fight it from the system side.

--- a/qt6ct/qt6ct.conf
+++ b/qt6ct/qt6ct.conf
@@ -1,0 +1,30 @@
+[Appearance]
+# Dark Qt theming for system-linked Qt apps (flameshot, qbittorrent, OBS, ...).
+# Fusion is the neutral cross-platform style that honours a custom palette.
+# darker.conf ships with the qt6ct package (/usr/share/qt6ct/colors/).
+color_scheme_path=/usr/share/qt6ct/colors/darker.conf
+custom_palette=true
+standard_dialogs=default
+style=Fusion
+
+[Interface]
+activate_item_on_single_click=1
+buttonbox_layout=0
+cursor_flash_time=1000
+dialog_buttons_have_icons=1
+double_click_interval=400
+gui_effects=@Invalid()
+keyboard_scheme=2
+menus_have_icons=true
+show_shortcuts_in_context_menus=true
+stylesheets=@Invalid()
+toolbutton_style=4
+underline_shortcut=1
+wheel_scroll_lines=3
+
+[SettingsWindow]
+geometry=@Invalid()
+
+[Troubleshooting]
+force_raster_widgets=1
+ignored_applications=@Invalid()


### PR DESCRIPTION
Closes #117

## What

Adds the fourth dark-theme delivery channel (Qt), removes a dead Wayland portal package, and documents how all four channels fit together.

## Changes

1. **Qt platform theme (dark).** Add `qt6ct` + `qt5ct` to `install.sh` packages; ship `qt6ct/qt6ct.conf` (Fusion style + `darker.conf` palette) symlinked into `~/.config/qt6ct/`; export `QT_QPA_PLATFORMTHEME=qt6ct` in `.xinitrc` before `exec i3`. This is the channel that themes flameshot and future qbittorrent/OBS.
2. **Portal hygiene.** Remove `xdg-desktop-portal-wlr` (wlroots/Wayland backend — dead weight on X11/i3; `-gtk` is the working backend). Fix the adjacent package comments.
3. **Docs.** New `nondeclarative/dark-theme.md` — the four channels, which config serves each, one example app per channel, and the **bundled Qt = in-app setting** rule (telegram, happ).

## Untouched (per issue "Do NOT touch")
- gsettings appearance block (GTK3/GTK4 channels)
- portals.conf / portal backend wiring
- dunst/rofi/alacritty/i3 theming

## Acceptance criteria
- [x] `grep -c "portal-wlr" install.sh` → 0
- [x] Theme matrix doc exists (all four channels + bundled-Qt rule)
- [x] Fresh-install path: packages + symlink + env, no manual steps
- [ ] flameshot config window renders dark — **needs verification on the machine** (primary target)

## Test plan (human on machine)
- Open flameshot configuration → should be dark
- Re-run install.sh → idempotent, no duplicate env exports
- blueman/pavucontrol still dark (no GTK regression)

> Note on the audit step: I could not run the on-machine audit (Qt ≥ 6.5 apps *may* already follow the portal color-scheme). I implemented the reliable qt6ct path so flameshot is dark regardless. If the audit shows Qt apps were already dark via the portal, this is harmless (still a correct dark palette) but could be reverted for step 2.