### PR TITLE
install.sh: don't report success when pacman -Syu fails

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-31T20:36:42.206Z for PR creation at branch issue-119-173f80144286 for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/119

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-31T20:36:42.206Z for PR creation at branch issue-119-173f80144286 for issue https://github.com/eg0rmaffin/vapor-rice-i3/issues/119

--- a/experiments/test-upgrade-failure.sh
+++ b/experiments/test-upgrade-failure.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# ─────────────────────────────────────────────
+# Test: install.sh must not report success when `pacman -Syu` fails
+#
+# Reproduces https://github.com/eg0rmaffin/vapor-rice-i3/issues/119
+#
+# Validates that perform_system_upgrade():
+#   1. On pacman failure: prints a red failure message, does NOT write the
+#      last-upgrade stamp, sets UPGRADE_FAILED=1 and returns non-zero
+#   2. On pacman success: writes both stamps and prints the green message
+#   3. install.sh ends with a red banner and exit 1 when UPGRADE_FAILED=1
+#
+# Usage: ./experiments/test-upgrade-failure.sh
+# ─────────────────────────────────────────────
+
+set -e
+
+GREEN="\033[0;32m"
+RED="\033[0;31m"
+CYAN="\033[0;36m"
+RESET="\033[0m"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+INSTALL_FILE="$REPO_DIR/install.sh"
+
+FAILURES=0
+
+pass() { echo -e "  ${GREEN}✅ $1${RESET}"; }
+fail() { echo -e "  ${RED}❌ $1${RESET}"; FAILURES=$((FAILURES + 1)); }
+
+# Extract a shell function definition (`name() {` ... `}` at column 0) from install.sh
+extract_fn() {
+    awk -v fn="$1" '$0 ~ "^"fn"\\(\\) \\{" {p=1} p {print} p && /^\}$/ {exit}' "$INSTALL_FILE"
+}
+
+# Build a sandbox that provides the upgrade functions plus a fake sudo/pacman
+# whose exit code we control via the PACMAN_EXIT variable.
+make_harness() {
+    local tmp="$1"
+    {
+        echo 'RED=""; GREEN=""; YELLOW=""; CYAN=""; RESET=""'
+        echo "UPGRADE_STAMP=\"$tmp/last-upgrade\""
+        echo "SYNC_STAMP=\"$tmp/last-sync\""
+        echo 'UPGRADE_FAILED=0'
+        echo 'sudo() { if [ "$1" = "pacman" ]; then return "${PACMAN_EXIT:-0}"; fi; return 0; }'
+        echo 'ensure_keyring_for_upgrade() { :; }'
+        extract_fn mark_synced
+        extract_fn mark_upgraded
+        extract_fn perform_system_upgrade
+    } > "$tmp/harness.sh"
+}
+
+echo -e "${CYAN}🧪 Testing install.sh upgrade failure handling${RESET}"
+echo ""
+
+# ─── Test 1: pacman fails ─────────────────────────────────────
+echo -e "${CYAN}Test 1: failed 'pacman -Syu' must not claim success${RESET}"
+TMP1=$(mktemp -d)
+make_harness "$TMP1"
+set +e
+OUT=$(PACMAN_EXIT=1 bash -c "source '$TMP1/harness.sh'; perform_system_upgrade; echo \"RC=\$?\"; echo \"FLAG=\$UPGRADE_FAILED\"" 2>&1)
+set -e
+
+echo "$OUT" | grep -q "RC=1" \
+    && pass "perform_system_upgrade returns non-zero" \
+    || fail "perform_system_upgrade returned zero on pacman failure"
+
+echo "$OUT" | grep -q "FLAG=1" \
+    && pass "UPGRADE_FAILED is set to 1" \
+    || fail "UPGRADE_FAILED was not set"
+
+echo "$OUT" | grep -q "System upgrade failed" \
+    && pass "failure message printed" \
+    || fail "no failure message printed"
+
+echo "$OUT" | grep -q "System upgraded and synced" \
+    && fail "success message printed despite failure" \
+    || pass "no success message printed"
+
+[ -f "$TMP1/last-upgrade" ] \
+    && fail "last-upgrade stamp was written despite failure" \
+    || pass "last-upgrade stamp NOT written"
+
+rm -rf "$TMP1"
+echo ""
+
+# ─── Test 2: pacman succeeds ──────────────────────────────────
+echo -e "${CYAN}Test 2: successful upgrade keeps previous behavior${RESET}"
+TMP2=$(mktemp -d)
+make_harness "$TMP2"
+set +e
+OUT=$(PACMAN_EXIT=0 bash -c "source '$TMP2/harness.sh'; perform_system_upgrade; echo \"RC=\$?\"" 2>&1)
+set -e
+
+echo "$OUT" | grep -q "RC=0" \
+    && pass "perform_system_upgrade returns zero" \
+    || fail "perform_system_upgrade returned non-zero on success"
+
+echo "$OUT" | grep -q "System upgraded and synced" \
+    && pass "success message printed" \
+    || fail "no success message printed"
+
+[ -f "$TMP2/last-upgrade" ] \
+    && pass "last-upgrade stamp written" \
+    || fail "last-upgrade stamp missing"
+
+[ -f "$TMP2/last-sync" ] \
+    && pass "last-sync stamp written" \
+    || fail "last-sync stamp missing"
+
+rm -rf "$TMP2"
+echo ""
+
+# ─── Test 3: final banner + non-zero exit ─────────────────────
+echo -e "${CYAN}Test 3: script ends with a red banner and exit 1 when UPGRADE_FAILED=1${RESET}"
+BANNER=$(awk '/^if \[ "\$UPGRADE_FAILED" -eq 1 \]; then/,/^fi$/' "$INSTALL_FILE")
+
+[ -n "$BANNER" ] \
+    && pass "final UPGRADE_FAILED banner exists" \
+    || fail "no final UPGRADE_FAILED banner found"
+
+echo "$BANNER" | grep -q "exit 1" \
+    && pass "banner exits with non-zero code" \
+    || fail "banner does not exit non-zero"
+
+# The banner must come before the final green "All done" line
+BANNER_LINE=$(grep -n '^if \[ "\$UPGRADE_FAILED" -eq 1 \]; then' "$INSTALL_FILE" | cut -d: -f1)
+DONE_LINE=$(grep -n 'All done! You can launch i3' "$INSTALL_FILE" | cut -d: -f1)
+if [ -n "$BANNER_LINE" ] && [ -n "$DONE_LINE" ] && [ "$BANNER_LINE" -lt "$DONE_LINE" ]; then
+    pass "banner is checked before the final success line"
+else
+    fail "banner is not checked before the final success line"
+fi
+echo ""
+
+# ─── Test 4: syntax check ─────────────────────────────────────
+echo -e "${CYAN}Test 4: install.sh is syntactically valid${RESET}"
+bash -n "$INSTALL_FILE" \
+    && pass "bash -n passes" \
+    || fail "bash -n failed"
+echo ""
+
+if [ "$FAILURES" -eq 0 ]; then
+    echo -e "${GREEN}🎉 All upgrade-failure tests passed${RESET}"
+    exit 0
+fi
+echo -e "${RED}❌ $FAILURES check(s) failed${RESET}"
+exit 1

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,10 @@ UPGRADE_STAMP="$HOME/.cache/vapor-rice/last-upgrade"
 
 FORCE_SYNC=0
 FORCE_UPGRADE=0
+# Set to 1 by perform_system_upgrade() when `pacman -Syu` returns non-zero.
+# The rest of the (local, network-independent) flow still runs, but the script
+# ends with a red banner and a non-zero exit code so success is never the last word.
+UPGRADE_FAILED=0
 NO_UPGRADE=0
 REPAIR_KEYRING=0
 for arg in "$@"; do
@@ -162,17 +166,31 @@ perform_system_upgrade() {
     # Ensure keyring is valid before upgrade
     ensure_keyring_for_upgrade
 
-    sudo pacman -Syu --noconfirm
-    mark_synced
-    mark_upgraded
-    echo -e "${GREEN}✅ System upgraded and synced${RESET}"
+    # Gate the stamps and the success message on pacman's exit code.
+    # A failed transaction (dead mirror mid-download, etc.) must NOT be reported
+    # as success and must NOT write the last-upgrade stamp.
+    if sudo pacman -Syu --noconfirm; then
+        mark_synced
+        mark_upgraded
+        echo -e "${GREEN}✅ System upgraded and synced${RESET}"
+        return 0
+    fi
+
+    UPGRADE_FAILED=1
+    echo -e "${RED}❌ System upgrade failed (pacman returned non-zero).${RESET}"
+    echo -e "${YELLOW}   Common cause: a mirror went down mid-download. Your system was NOT modified (pacman rolls back atomically).${RESET}"
+    echo -e "${YELLOW}   Try re-running, or refresh mirrors, then './install.sh --upgrade' again.${RESET}"
+    return 1
 }
 
 # Check if explicit upgrade was requested via --upgrade flag
 check_explicit_upgrade() {
     if [[ "$FORCE_UPGRADE" -eq 1 ]]; then
         echo -e "${CYAN}🔄 Full system upgrade requested (--upgrade flag)${RESET}"
-        perform_system_upgrade
+        # Decision (a): a failed upgrade does not stop the rest of the flow —
+        # symlinks, systemd units and gsettings are local and network-independent.
+        # The failure is surfaced loudly by the final banner (see UPGRADE_FAILED).
+        perform_system_upgrade || true
         return 0
     fi
     return 1
@@ -326,7 +344,9 @@ install_list() {
         echo ""
         echo -e "${CYAN}🔄 Performing single fallback system upgrade to resolve...${RESET}"
 
-        perform_system_upgrade
+        # Never abort here: even if the upgrade fails (dead mirror), we still want
+        # to retry the install and let the final banner report the failure.
+        perform_system_upgrade || true
 
         echo -e "${CYAN}📦 Retrying package installation...${RESET}"
         if sudo pacman -S --needed --noconfirm "${pkgs[@]}"; then
@@ -1212,6 +1232,26 @@ if [ ${#REPO_MISSING_LOCAL_INSTALLED[@]} -gt 0 ]; then
     echo -e "  pacman -Q <package>      # verify local installation"
     echo -e "  pacman -Si <package>     # check repo availability"
     echo ""
+fi
+
+# ─────────────────────────────────────────────
+# ❌ Upgrade failure banner
+# The local part of the flow is idempotent and network-independent, so a failed
+# `pacman -Syu` does not stop it — but it must never end with a green message.
+if [ "$UPGRADE_FAILED" -eq 1 ]; then
+    echo ""
+    echo -e "${RED}┌─────────────────────────────────────────────────────────────┐${RESET}"
+    echo -e "${RED}│                ❌ SYSTEM UPGRADE FAILED                     │${RESET}"
+    echo -e "${RED}└─────────────────────────────────────────────────────────────┘${RESET}"
+    echo ""
+    echo -e "${YELLOW}Dotfiles configuration was applied, but 'pacman -Syu' did NOT succeed.${RESET}"
+    echo -e "${YELLOW}The last-upgrade stamp was not written, so the upgrade will be retried.${RESET}"
+    echo ""
+    echo -e "${CYAN}Next steps:${RESET}"
+    echo -e "  ./install.sh --upgrade      # retry the upgrade (refreshes databases)"
+    echo -e "  # if a mirror is down: refresh /etc/pacman.d/mirrorlist first"
+    echo ""
+    exit 1
 fi
 
 # 🎉 Финал


### PR DESCRIPTION
Fixes #119

## Problem

`perform_system_upgrade()` ran `sudo pacman -Syu --noconfirm` without checking its exit code, then unconditionally called `mark_upgraded` and printed the green `✅ System upgraded and synced`.

Root cause of why `set -e` didn't catch it: the `--upgrade` entry point is invoked as `check_explicit_upgrade || true` (install.sh:542), which suspends errexit for the entire call chain. So a failed transaction (mirror dying mid-download → `failed to retrieve some files`) printed success on top of pacman's red errors **and** wrote `~/.cache/vapor-rice/last-upgrade`, falsely marking the system as recently upgraded.

## Fix

- `perform_system_upgrade()` gates `mark_synced` / `mark_upgraded` and the success message on pacman's exit code. On failure it prints a red diagnostic, sets `UPGRADE_FAILED=1` and returns non-zero.
- **Decision: (a)** — a failed upgrade does not abort the run. Symlinks, systemd units and gsettings are local and network-independent; a flapping mirror shouldn't block re-linking configs.
- …but the last word is honest: a new final banner prints a red `❌ SYSTEM UPGRADE FAILED` block and `exit 1` when `UPGRADE_FAILED=1`, before the green "All done" line.
- The fallback call site (dependency-conflict recovery inside `install_list`) uses `perform_system_upgrade || true` so the retry still happens under `set -e`.

## Reproduction & test

`experiments/test-upgrade-failure.sh` extracts the upgrade functions from `install.sh` into a sandbox with a fake `sudo`/`pacman` whose exit code is controlled by `PACMAN_EXIT`.

- Against the **previous** implementation: 8 checks fail (returns 0, no failure message, success message printed, stamp written, no final banner).
- Against **this** branch: all checks pass.

Covers the acceptance criteria:
- failed upgrade → red failure message, **no** `last-upgrade` stamp, non-zero final exit
- successful upgrade → unchanged (both stamps written, green message)
- no `--upgrade` flag → unchanged (`UPGRADE_FAILED` stays 0, banner skipped)

```
$ ./experiments/test-upgrade-failure.sh
🎉 All upgrade-failure tests passed
```

Existing suites still pass, including `experiments/test-arch-safety.sh` (22 passed) — the banner text deliberately avoids suggesting a bare `pacman -Syy`, which that suite forbids.